### PR TITLE
chore: bump skills/exercise-toolkit to v0.9.3 and action-keyphrase-checker to v2

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -19,7 +19,7 @@ jobs:
     if: |
       !github.event.repository.is_template
     name: Start Exercise
-    uses: skills/exercise-toolkit/.github/workflows/start-exercise.yml@v0.9.0
+    uses: skills/exercise-toolkit/.github/workflows/start-exercise.yml@v0.9.3
     with:
       exercise-title: "Getting Started with Agentic Workflows"
       intro-message: "Practice installing and creating agentic workflows for Mona's GitHub Info website"
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.9.0
+          ref: v0.9.3
 
       - name: Create comment - add step content
         uses: GrantBirki/comment@v2.1.1

--- a/.github/workflows/1-step.yml
+++ b/.github/workflows/1-step.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   find_exercise:
     name: Find Exercise Issue
-    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.9.0
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.9.3
 
   check_step_work:
     name: Check step work
@@ -36,7 +36,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.9.0
+          ref: v0.9.3
 
       - name: Find last comment
         id: find-last-comment
@@ -58,14 +58,14 @@ jobs:
       - name: Check setup workflow exists
         id: check-setup-file
         continue-on-error: true
-        uses: skills/exercise-toolkit/actions/file-exists@v0.9.0
+        uses: skills/exercise-toolkit/actions/file-exists@v0.9.3
         with:
           file: .github/workflows/copilot-setup-steps.yml
 
       - name: Check workflow installs gh-aw
         id: check-setup-action
         continue-on-error: true
-        uses: skills/action-keyphrase-checker@v1
+        uses: skills/action-keyphrase-checker@v2
         with:
           text-file: .github/workflows/copilot-setup-steps.yml
           keyphrase: github/gh-aw/actions/setup-cli
@@ -73,7 +73,7 @@ jobs:
       - name: Check workflow has copilot-setup-steps job
         id: check-setup-job
         continue-on-error: true
-        uses: skills/action-keyphrase-checker@v1
+        uses: skills/action-keyphrase-checker@v2
         with:
           text-file: .github/workflows/copilot-setup-steps.yml
           keyphrase: copilot-setup-steps
@@ -117,7 +117,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.9.0
+          ref: v0.9.3
 
       - name: Create comment - step finished
         uses: GrantBirki/comment@v2.1.1

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   find_exercise:
     name: Find Exercise Issue
-    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.9.0
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.9.3
 
   check_step_work:
     name: Check step work
@@ -37,7 +37,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.9.0
+          ref: v0.9.3
 
       - name: Find last comment
         id: find-last-comment
@@ -59,14 +59,14 @@ jobs:
       - name: Check website content file exists
         id: check-site-file
         continue-on-error: true
-        uses: skills/exercise-toolkit/actions/file-exists@v0.9.0
+        uses: skills/exercise-toolkit/actions/file-exists@v0.9.3
         with:
           file: site/content/github-info.md
 
       - name: Check website includes latest updates section
         id: check-site-content
         continue-on-error: true
-        uses: skills/action-keyphrase-checker@v1
+        uses: skills/action-keyphrase-checker@v2
         with:
           text-file: site/content/github-info.md
           keyphrase: Latest GitHub Updates
@@ -74,7 +74,7 @@ jobs:
       - name: Check workflow file exists
         id: check-workflow-file
         continue-on-error: true
-        uses: skills/exercise-toolkit/actions/file-exists@v0.9.0
+        uses: skills/exercise-toolkit/actions/file-exists@v0.9.3
         with:
           file: .github/workflows/update-github-info.md
 
@@ -135,7 +135,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.9.0
+          ref: v0.9.3
 
       - name: Create comment - step finished
         uses: GrantBirki/comment@v2.1.1

--- a/.github/workflows/3-last-step.yml
+++ b/.github/workflows/3-last-step.yml
@@ -19,7 +19,7 @@ jobs:
   find_exercise:
     if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     name: Find Exercise Issue
-    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.9.0
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.9.3
 
   check_step_work:
     if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.9.0
+          ref: v0.9.3
 
       - name: Find last comment
         id: find-last-comment
@@ -61,14 +61,14 @@ jobs:
       - name: Check workflow file exists
         id: check-workflow-file
         continue-on-error: true
-        uses: skills/exercise-toolkit/actions/file-exists@v0.9.0
+        uses: skills/exercise-toolkit/actions/file-exists@v0.9.3
         with:
           file: .github/workflows/update-github-info.md
 
       - name: Check workflow supports manual runs
         id: check-workflow-dispatch
         continue-on-error: true
-        uses: skills/action-keyphrase-checker@v1
+        uses: skills/action-keyphrase-checker@v2
         with:
           text-file: .github/workflows/update-github-info.md
           keyphrase: workflow_dispatch
@@ -76,7 +76,7 @@ jobs:
       - name: Check workflow has a schedule
         id: check-workflow-schedule
         continue-on-error: true
-        uses: skills/action-keyphrase-checker@v1
+        uses: skills/action-keyphrase-checker@v2
         with:
           text-file: .github/workflows/update-github-info.md
           keyphrase: schedule
@@ -139,7 +139,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.9.0
+          ref: v0.9.3
 
       - name: Create comment - step finished - final review next
         uses: GrantBirki/comment@v2.1.1
@@ -164,7 +164,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     name: Finish Exercise
     needs: [find_exercise, post_review_content]
-    uses: skills/exercise-toolkit/.github/workflows/finish-exercise.yml@v0.9.0
+    uses: skills/exercise-toolkit/.github/workflows/finish-exercise.yml@v0.9.3
     with:
       issue-url: ${{ needs.find_exercise.outputs.issue-url }}
       exercise-title: "Getting Started with Agentic Workflows"


### PR DESCRIPTION
## Summary

Routine version bump of the two shared Skills dependencies used by the grading workflows.

| Dependency | Before | After |
|---|---|---|
| `skills/exercise-toolkit` | `v0.9.0` | **`v0.9.3`** |
| `skills/action-keyphrase-checker` | `v1` | **`v2`** |

## Changes

- All `@v0.9.0` references in `.github/workflows/` (reusable workflows + the `file-exists` action) bumped to `@v0.9.3`.
- All `ref: v0.9.0` checkouts of the toolkit repo bumped to `ref: v0.9.3`.
- `skills/action-keyphrase-checker@v1` → `@v2` (kept floating-major pin to match existing style).

## Compatibility notes

- **`exercise-toolkit` v0.9.1 → v0.9.3** are patch releases (image-URL fix for private templates, `wait-for-workflow` improvements, dep bumps). The reusable workflows used here (`start-exercise`, `find-exercise-issue`, `finish-exercise`) and the `file-exists` action have unchanged input/output contracts.
- **`action-keyphrase-checker` v2.0.0** is a major release, but the only change is an internal node20 → node24 migration. Inputs/outputs are unchanged, and `ubuntu-latest` runners support node24 — drop-in safe.
- Skipped draft `exercise-toolkit` `v0.9.4` (still untagged at time of writing).

## Validation

- ✅ All four workflow YAML files parse cleanly.
- ✅ `grep` confirms zero remaining stale refs (`@v0.9.0`, `ref: v0.9.0`, `action-keyphrase-checker@v1`) in `.github/workflows/`.
- The Step 2 grading workflow runs on PRs to `main` and exercises the bumped `find-exercise-issue` reusable workflow, the `file-exists` action, and `action-keyphrase-checker` together — checks should pass for an unrelated PR (no exercise files added) until merge gating, but action resolution itself will smoke-test the upgrade.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;