### PR TITLE
Expand agentic workflows exercise lifecycle

### DIFF
--- a/.github/images/actions-secrets-settings.svg
+++ b/.github/images/actions-secrets-settings.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="420" role="img" aria-labelledby="title desc">
+  <title id="title">Actions secrets settings placeholder</title>
+  <desc id="desc">Placeholder showing repository settings, secrets and variables, and Actions selected.</desc>
+  <rect width="900" height="420" fill="#f6f8fa"/>
+  <rect x="24" y="24" width="852" height="372" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="48" y="64" font-family="Arial, sans-serif" font-size="24" font-weight="700" fill="#24292f">Repository settings</text>
+  <rect x="48" y="96" width="220" height="260" rx="8" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="72" y="132" font-family="Arial, sans-serif" font-size="16" fill="#57606a">General</text>
+  <text x="72" y="172" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#0969da">Secrets and variables</text>
+  <text x="96" y="206" font-family="Arial, sans-serif" font-size="15" font-weight="700" fill="#24292f">Actions</text>
+  <text x="72" y="246" font-family="Arial, sans-serif" font-size="16" fill="#57606a">Environments</text>
+  <rect x="304" y="104" width="520" height="72" rx="8" fill="#ddf4ff" stroke="#54aeff"/>
+  <text x="328" y="148" font-family="Arial, sans-serif" font-size="18" fill="#24292f">Settings &gt; Secrets and variables &gt; Actions</text>
+  <rect x="304" y="212" width="240" height="48" rx="6" fill="#2da44e"/>
+  <text x="336" y="243" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#ffffff">New repository secret</text>
+  <text x="304" y="308" font-family="Arial, sans-serif" font-size="15" fill="#57606a">Replace this placeholder with a screenshot from a copied exercise repository.</text>
+</svg>

--- a/.github/images/add-copilot-github-token-secret.svg
+++ b/.github/images/add-copilot-github-token-secret.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="420" role="img" aria-labelledby="title desc">
+  <title id="title">COPILOT_GITHUB_TOKEN secret placeholder</title>
+  <desc id="desc">Placeholder showing a new repository secret form with COPILOT_GITHUB_TOKEN as the secret name and no token value.</desc>
+  <rect width="900" height="420" fill="#f6f8fa"/>
+  <rect x="80" y="40" width="740" height="340" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="120" y="88" font-family="Arial, sans-serif" font-size="24" font-weight="700" fill="#24292f">New repository secret</text>
+  <text x="120" y="136" font-family="Arial, sans-serif" font-size="15" font-weight="700" fill="#24292f">Name</text>
+  <rect x="120" y="152" width="520" height="42" rx="6" fill="#ffffff" stroke="#8c959f"/>
+  <text x="136" y="180" font-family="Arial, sans-serif" font-size="16" fill="#24292f">COPILOT_GITHUB_TOKEN</text>
+  <text x="120" y="232" font-family="Arial, sans-serif" font-size="15" font-weight="700" fill="#24292f">Secret</text>
+  <rect x="120" y="248" width="640" height="72" rx="6" fill="#ffffff" stroke="#8c959f"/>
+  <text x="136" y="290" font-family="Arial, sans-serif" font-size="16" fill="#6e7781">Paste token value here in the real UI. Do not show it in screenshots.</text>
+  <rect x="120" y="340" width="120" height="40" rx="6" fill="#2da44e"/>
+  <text x="145" y="365" font-family="Arial, sans-serif" font-size="15" font-weight="700" fill="#ffffff">Add secret</text>
+</svg>

--- a/.github/images/generated-update-pr.svg
+++ b/.github/images/generated-update-pr.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="420" role="img" aria-labelledby="title desc">
+  <title id="title">Generated pull request placeholder</title>
+  <desc id="desc">Placeholder showing a generated Mona website update pull request in the pull request list.</desc>
+  <rect width="900" height="420" fill="#f6f8fa"/>
+  <rect x="36" y="36" width="828" height="348" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="64" y="84" font-family="Arial, sans-serif" font-size="24" font-weight="700" fill="#24292f">Pull requests</text>
+  <rect x="64" y="120" width="772" height="72" rx="8" fill="#f6f8fa" stroke="#d0d7de"/>
+  <circle cx="92" cy="156" r="10" fill="#1a7f37"/>
+  <text x="120" y="150" font-family="Arial, sans-serif" font-size="17" font-weight="700" fill="#0969da">[mona] Update GitHub Info website</text>
+  <text x="120" y="176" font-family="Arial, sans-serif" font-size="14" fill="#57606a">opened by github-actions after running update-github-info</text>
+  <rect x="64" y="224" width="772" height="88" rx="8" fill="#ddf4ff" stroke="#54aeff"/>
+  <text x="88" y="260" font-family="Arial, sans-serif" font-size="17" fill="#24292f">Open the generated pull request and review Mona's proposed website update.</text>
+  <text x="88" y="288" font-family="Arial, sans-serif" font-size="15" fill="#57606a">Replace this placeholder with a screenshot from a copied exercise repository.</text>
+</svg>

--- a/.github/images/pr-files-changed-github-info.svg
+++ b/.github/images/pr-files-changed-github-info.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="420" role="img" aria-labelledby="title desc">
+  <title id="title">Pull request files changed placeholder</title>
+  <desc id="desc">Placeholder showing the Files changed tab with site/content/github-info.md.</desc>
+  <rect width="900" height="420" fill="#f6f8fa"/>
+  <rect x="36" y="36" width="828" height="348" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="64" y="84" font-family="Arial, sans-serif" font-size="24" font-weight="700" fill="#24292f">Pull request review</text>
+  <rect x="64" y="112" width="772" height="44" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="92" y="140" font-family="Arial, sans-serif" font-size="16" fill="#57606a">Conversation</text>
+  <text x="236" y="140" font-family="Arial, sans-serif" font-size="16" fill="#57606a">Commits</text>
+  <text x="356" y="140" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#24292f">Files changed</text>
+  <rect x="64" y="196" width="772" height="144" rx="8" fill="#ffffff" stroke="#d0d7de"/>
+  <rect x="64" y="196" width="772" height="40" rx="8" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="88" y="222" font-family="Arial, sans-serif" font-size="15" font-weight="700" fill="#24292f">site/content/github-info.md</text>
+  <text x="88" y="270" font-family="Arial, sans-serif" font-size="15" fill="#1a7f37">+ ## Latest GitHub Updates</text>
+  <text x="88" y="302" font-family="Arial, sans-serif" font-size="15" fill="#1a7f37">+ Source: GitHub Blog or GitHub Changelog</text>
+</svg>

--- a/.github/images/run-workflow-button.svg
+++ b/.github/images/run-workflow-button.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="420" role="img" aria-labelledby="title desc">
+  <title id="title">Run workflow button placeholder</title>
+  <desc id="desc">Placeholder showing the GitHub Actions Run workflow button.</desc>
+  <rect width="900" height="420" fill="#f6f8fa"/>
+  <rect x="32" y="32" width="836" height="356" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="64" y="80" font-family="Arial, sans-serif" font-size="24" font-weight="700" fill="#24292f">Actions</text>
+  <rect x="64" y="112" width="260" height="220" rx="8" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="88" y="150" font-family="Arial, sans-serif" font-size="16" fill="#57606a">All workflows</text>
+  <text x="88" y="190" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#0969da">update-github-info</text>
+  <rect x="612" y="112" width="172" height="44" rx="6" fill="#2da44e"/>
+  <text x="640" y="140" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#ffffff">Run workflow</text>
+  <rect x="372" y="196" width="412" height="88" rx="8" fill="#ddf4ff" stroke="#54aeff"/>
+  <text x="396" y="232" font-family="Arial, sans-serif" font-size="17" fill="#24292f">Select the compiled updater workflow,</text>
+  <text x="396" y="260" font-family="Arial, sans-serif" font-size="17" fill="#24292f">then choose Run workflow.</text>
+</svg>

--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -20,13 +20,34 @@ GitHub Agentic Workflows use repository files and GitHub Actions to give AI agen
 
 The [`gh aw` CLI](https://github.github.com/gh-aw/setup/cli/) and setup action are commonly used to prepare a repository for agentic workflows. In this exercise, you'll add the repository setup as code, review it in a pull request, and then merge it to `main`.
 
-### ⌨️ Activities
+### :keyboard: Activity: Set up your Codespace and agentic workflow tooling
 
-1. Create a new branch from `main`.
+Let's start in the pre-configured Codespace for this exercise. The dev container installs the website dependencies and enables the GitHub Copilot extensions for VS Code.
 
-2. Add `.github/workflows/copilot-setup-steps.yml` with a workflow that checks out the repository and installs the `gh-aw` CLI by using `github/gh-aw/actions/setup-cli`.
+1. Use the button below to open the **Create Codespace** page in a new tab. Use the default configuration.
 
-3. You can use this starter example:
+   [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/{{full_repo_name}}?quickstart=1)
+
+2. Confirm the **Repository** field is your copy of the exercise, not the original template, then click the green **Create Codespace** button.
+   - ✅ Your copy: `/{{full_repo_name}}`
+   - ❌ Original: `/skills-dev/getting-started-with-agentic-workflows`
+
+3. Wait for Visual Studio Code to load in your browser. The `.devcontainer` setup may take a few minutes while it installs dependencies and verifies the Astro site build.
+
+4. Open Copilot Chat and switch to **Agent** mode.
+
+5. Ask Copilot to create the setup workflow for you.
+
+   > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
+   >
+   > ```prompt
+   > Create a new branch named install-agentic-workflows.
+   > Add .github/workflows/copilot-setup-steps.yml with a workflow named "Copilot Setup Steps".
+   > The workflow should run on workflow_dispatch and when .github/workflows/copilot-setup-steps.yml changes.
+   > Add a job named copilot-setup-steps that runs on ubuntu-latest, checks out the repository, and installs the gh-aw CLI using github/gh-aw/actions/setup-cli@main.
+   > ```
+
+6. Review Copilot's suggested changes. The finished file should look similar to this:
 
    ```yaml
    name: "Copilot Setup Steps"
@@ -49,11 +70,18 @@ The [`gh aw` CLI](https://github.github.com/gh-aw/setup/cli/) and setup action a
            uses: github/gh-aw/actions/setup-cli@main
    ```
 
-4. Open a pull request for your branch.
+7. Ask Copilot to commit, push, and open a pull request.
 
-5. Merge the pull request into `main`.
+   > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
+   >
+   > ```prompt
+   > Commit the setup workflow change, push the install-agentic-workflows branch, and open a pull request into main.
+   > Use the pull request title "Add Copilot setup workflow".
+   > ```
 
-6. Wait about 20 seconds, then refresh the exercise issue for the next step.
+8. Merge the pull request into `main`.
+
+9. Wait about 20 seconds, then refresh the exercise issue for the next step.
 
 <details>
 <summary>Having trouble? 🤷</summary><br/>

--- a/.github/steps/2-step.md
+++ b/.github/steps/2-step.md
@@ -8,23 +8,35 @@ An agentic workflow can read repository context, compare sources, draft changes,
 
 In this step, you'll create a workflow definition in `.github/workflows/` and pair it with a real content update in the website source. Your workflow should tell the agent to read Mona's notes, check the GitHub Blog and the GitHub Changelog, and then prepare a pull request for Mona to review.
 
-### ⌨️ Activities
+### :keyboard: Activity: Create Mona's updater workflow
 
-1. Create a new branch from `main` for Mona's content workflow.
+Continue working in VS Code. If you closed your browser editor, reopen your development environment from your repository's **Code** menu.
 
-2. Update `site/content/github-info.md` with a fresh website change. For example, add a new section like `## Latest GitHub Updates` and include at least one short update for readers.
+1. Ask Copilot to create the content workflow branch and draft the required files.
 
-3. Create `.github/workflows/update-github-info.md` for your agentic workflow.
+   > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
+   >
+   > ```prompt
+   > Make sure I am on the latest main branch, then create a new branch named create-mona-updater.
+   > Update site/content/github-info.md with a new section named "Latest GitHub Updates" and include at least one concise update for readers.
+   > Create .github/workflows/update-github-info.md as an agentic workflow markdown file.
+   > Give the workflow edit access through the tools configuration.
+   > The workflow should use safe-outputs with create-pull-request so the agent can propose changes without writing directly to main.
+   > The workflow instructions should tell the agent to read notes/mona-notes.md, use the GitHub Blog, use the GitHub Changelog, update site/content/github-info.md, and open a pull request for Mona to review.
+   > Ask the agent to use a pull request title that mentions Mona or GitHub Info.
+   > ```
 
-4. In that workflow file, make sure you clearly instruct the agent to:
+2. Review Copilot's suggested changes. Make sure `site/content/github-info.md` includes `## Latest GitHub Updates`.
+
+3. In `.github/workflows/update-github-info.md`, make sure Copilot clearly instructed the agent to:
 
    - read `notes/mona-notes.md`
    - use the GitHub Blog
    - use the GitHub Changelog
    - update `site/content/github-info.md`
-   - create a pull request for Mona to review
+   - create a pull request for Mona to review using `safe-outputs`
 
-5. If you'd like a starting point, use something like this and customize it:
+4. The workflow file should look similar to this:
 
    ```markdown
    ---
@@ -32,6 +44,17 @@ In this step, you'll create a workflow definition in `.github/workflows/` and pa
    description: Draft website updates for Mona's GitHub Info site.
    on:
      workflow_dispatch:
+   safe-outputs:
+     create-pull-request:
+       title-prefix: "[mona] "
+       draft: true
+       fallback-as-issue: false
+   tools:
+     edit:
+   network:
+     allowed:
+       - github.com
+       - github.blog
    ---
 
    # Update Mona's GitHub Info website
@@ -43,18 +66,25 @@ In this step, you'll create a workflow definition in `.github/workflows/` and pa
    - GitHub Blog
    - GitHub Changelog
 
-   Update the website with concise changes and open a pull request for Mona to review.
+   Update the website with concise changes and open a pull request for Mona to review. Use a pull request title that mentions Mona or GitHub Info.
    ```
 
-6. Commit your changes and open a pull request from your branch into `main`.
+5. Ask Copilot to commit, push, and open a pull request.
 
-7. Wait about 20 seconds, then refresh the exercise issue for the next step.
+   > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
+   >
+   > ```prompt
+   > Commit the website content and agentic workflow changes, push the create-mona-updater branch, and open a pull request into main.
+   > Use the pull request title "Create Mona website updater workflow".
+   > ```
+
+6. Keep the pull request open. Wait about 20 seconds, then refresh the exercise issue for the next step.
 
 <details>
 <summary>Having trouble? 🤷</summary><br/>
 
 - The grading check looks for both a website content update and a new workflow file.
-- Include the phrases `GitHub Blog`, `GitHub Changelog`, and `pull request` in `.github/workflows/update-github-info.md`.
+- Include the phrases `GitHub Blog`, `GitHub Changelog`, `safe-outputs`, `create-pull-request`, and `pull request` in `.github/workflows/update-github-info.md`.
 - Keep your workflow in markdown (`.md`) so the exercise focuses on the agent instructions.
 
 </details>

--- a/.github/steps/3-step.md
+++ b/.github/steps/3-step.md
@@ -8,30 +8,44 @@ A useful agentic workflow is more than a one-off prompt. It should be easy to ru
 
 In this step, you'll turn Mona's updater into a repeatable process by giving it both manual and scheduled triggers. You'll also document the review loop in the repository so future collaborators know where the website content comes from and why updates still go through pull requests.
 
-### ⌨️ Activities
+### :keyboard: Activity: Operationalize Mona's updater
 
-1. Update `.github/workflows/update-github-info.md` so the workflow can run both:
+Continue working in the same VS Code window and pull request branch from Step 2.
 
-   - manually with `workflow_dispatch`
-   - automatically on a daily `schedule`
+1. Ask Copilot to make Mona's updater repeatable and documented.
 
-2. Update `README.md` with a short section that explains:
+   > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
+   >
+   > ```prompt
+   > Update .github/workflows/update-github-info.md so the workflow can run manually with workflow_dispatch and automatically on a daily schedule.
+   > Also update README.md with a short section that explains Mona's GitHub Info website is updated from notes/mona-notes.md, the GitHub Blog, and the GitHub Changelog.
+   > The README should also explain that the workflow opens pull requests for Mona to review before changes are merged.
+   > ```
 
-   - Mona's GitHub Info website is updated from `notes/mona-notes.md`
-   - the workflow also uses the GitHub Blog and GitHub Changelog
-   - the workflow opens pull requests for Mona to review before changes are merged
+2. Review Copilot's suggested changes. Make sure:
 
-3. Commit the updates to the same pull request from Step 2.
+   - `.github/workflows/update-github-info.md` includes both `workflow_dispatch` and `schedule`
+   - `README.md` mentions `notes/mona-notes.md`
+   - `README.md` mentions the GitHub Blog and GitHub Changelog
+   - `README.md` explains the pull request review process
+
+3. Ask Copilot to commit and push the updates to the same pull request from Step 2.
+
+   > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
+   >
+   > ```prompt
+   > Commit the workflow scheduling and README documentation updates, then push them to the current branch.
+   > ```
 
 4. Merge the pull request into `main`.
 
-5. Wait about 20 seconds, then refresh the exercise issue for the final review.
+5. Wait about 20 seconds, then refresh the exercise issue for the next step.
 
 <details>
 <summary>Having trouble? 🤷</summary><br/>
 
 - The final check looks for both `workflow_dispatch` and `schedule` in `.github/workflows/update-github-info.md`.
 - Make sure your `README.md` mentions the GitHub Blog, GitHub Changelog, and pull requests.
-- If the final review does not appear, check the [Actions](../../actions) tab and confirm your pull request was merged.
+- If the next step does not appear, check the [Actions](../../actions) tab and confirm your pull request was merged.
 
 </details>

--- a/.github/steps/4-step.md
+++ b/.github/steps/4-step.md
@@ -1,0 +1,63 @@
+## Step 4: Run Mona's updater and review the generated pull request
+
+You now have an agentic workflow definition for Mona's website. In this step, you'll run it and inspect the pull request it creates.
+
+### 📖 Theory: From workflow definition to generated pull request
+
+Agentic workflows are authored as markdown files, but GitHub Actions runs compiled `.lock.yml` workflow files. The `gh aw compile` command turns `.github/workflows/update-github-info.md` into `.github/workflows/update-github-info.lock.yml`.
+
+Because this workflow uses the default Copilot engine, the repository needs a `COPILOT_GITHUB_TOKEN` Actions secret before the compiled workflow can run. That secret is a fine-grained personal access token with the **Copilot Requests** account permission.
+
+The workflow uses `safe-outputs: create-pull-request`, so the agent can draft website changes without writing directly to `main`. The agent prepares a patch, and a separate permission-controlled job opens a pull request for Mona to review.
+
+### :keyboard: Activity: Run the updater and inspect its pull request
+
+1. Confirm the repository has the `COPILOT_GITHUB_TOKEN` secret.
+
+   Go to your repository on GitHub, then choose **Settings** > **Secrets and variables** > **Actions**.
+
+   <img width="650" alt="Repository actions secrets settings page" src="../images/actions-secrets-settings.svg" />
+
+   If the secret is missing, [create a fine-grained personal access token](https://github.com/settings/personal-access-tokens/new?name=COPILOT_GITHUB_TOKEN&description=GitHub+Agentic+Workflows+-+Copilot+engine+authentication&user_copilot_requests=read) with **Copilot Requests** set to **Read**, then add it as a repository secret named `COPILOT_GITHUB_TOKEN`.
+
+   <img width="650" alt="New repository secret form with COPILOT_GITHUB_TOKEN as the secret name" src="../images/add-copilot-github-token-secret.svg" />
+
+   > [!CAUTION]
+   > Never paste a real token into a comment, markdown file, pull request, or Copilot Chat message. Only add it through the repository secrets UI.
+
+2. Ask Copilot to compile and run Mona's updater.
+
+   > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
+   >
+   > ```prompt
+   > Check that gh-aw is available in this repository.
+   > Make sure I am on the latest main branch before changing files.
+   > Update notes/mona-notes.md with a short section named "Mona updater request" that asks the updater to highlight one recent GitHub Blog or GitHub Changelog update.
+   > Compile .github/workflows/update-github-info.md with gh aw compile.
+   > Confirm .github/workflows/update-github-info.lock.yml was created and references COPILOT_GITHUB_TOKEN.
+   > Then run the update-github-info workflow with gh aw run update-github-info --push --ref main and help me open the generated workflow run.
+   > ```
+
+3. If you prefer the GitHub UI, open the **Actions** tab, select the compiled updater workflow, and choose **Run workflow**.
+
+   <img width="650" alt="GitHub Actions run workflow button" src="../images/run-workflow-button.svg" />
+
+4. Wait for the workflow to create a pull request for Mona's website update.
+
+   <img width="650" alt="Pull request list showing a generated Mona website update pull request" src="../images/generated-update-pr.svg" />
+
+5. Open the generated pull request and review the **Files changed** tab. Confirm it updates `site/content/github-info.md` and mentions the source of the update.
+
+   <img width="650" alt="Pull request files changed tab showing site/content/github-info.md" src="../images/pr-files-changed-github-info.svg" />
+
+6. Leave the generated pull request open. When the updater workflow finishes, Mona will look for an open pull request that updates `site/content/github-info.md`. Wait about 20 seconds, then refresh the exercise issue for the final review.
+
+<details>
+<summary>Having trouble? 🤷</summary><br/>
+
+- If the workflow fails before the agent starts, confirm `COPILOT_GITHUB_TOKEN` is configured as an Actions secret.
+- If compilation fails, make sure `.github/workflows/update-github-info.md` includes `safe-outputs`, `create-pull-request`, `workflow_dispatch`, and a `network` allowlist.
+- If no pull request appears, open the failed workflow run from the **Actions** tab and review the logs.
+- If the pull request opens as a draft, that is expected. Mona should review generated website changes before they merge.
+
+</details>

--- a/.github/steps/x-review.md
+++ b/.github/steps/x-review.md
@@ -10,6 +10,7 @@ Here's what you accomplished:
 - **Created a website updater** — You drafted a workflow for Mona's GitHub Info website that uses repository notes plus the GitHub Blog and GitHub Changelog.
 - **Added a human review loop** — You designed the workflow to propose changes in a pull request for Mona.
 - **Operationalized the workflow** — You added manual and scheduled execution and documented how the automation works.
+- **Ran the agentic workflow** — You compiled Mona's updater, ran it, and inspected the pull request it generated.
 
 ### What's next?
 

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -105,6 +105,7 @@ jobs:
         run: |
           grep -q 'network' .github/workflows/update-github-info.md
           grep -q 'github.blog' .github/workflows/update-github-info.md
+          grep -q 'github.com' .github/workflows/update-github-info.md
 
       - name: Update comment - step results
         uses: GrantBirki/comment@v2.1.1

--- a/.github/workflows/3-step.yml
+++ b/.github/workflows/3-step.yml
@@ -1,9 +1,9 @@
-name: Step 2
+name: Step 3
 
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [closed]
     branches:
       - main
 
@@ -13,14 +13,16 @@ permissions:
   issues: write
 
 env:
-  STEP_3_FILE: ".github/steps/3-step.md"
+  STEP_4_FILE: ".github/steps/4-step.md"
 
 jobs:
   find_exercise:
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     name: Find Exercise Issue
     uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.9.3
 
   check_step_work:
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     name: Check step work
     runs-on: ubuntu-latest
     needs: [find_exercise]
@@ -56,21 +58,6 @@ jobs:
           file: exercise-toolkit/markdown-templates/step-feedback/checking-work.md
           edit-mode: replace
 
-      - name: Check website content file exists
-        id: check-site-file
-        continue-on-error: true
-        uses: skills/exercise-toolkit/actions/file-exists@v0.9.3
-        with:
-          file: site/content/github-info.md
-
-      - name: Check website includes latest updates section
-        id: check-site-content
-        continue-on-error: true
-        uses: skills/action-keyphrase-checker@v2
-        with:
-          text-file: site/content/github-info.md
-          keyphrase: Latest GitHub Updates
-
       - name: Check workflow file exists
         id: check-workflow-file
         continue-on-error: true
@@ -78,33 +65,35 @@ jobs:
         with:
           file: .github/workflows/update-github-info.md
 
-      - name: Check workflow uses all three sources
-        id: check-workflow-sources
+      - name: Check workflow supports manual runs
+        id: check-workflow-dispatch
         continue-on-error: true
-        run: |
-          grep -q 'notes/mona-notes.md' .github/workflows/update-github-info.md
-          grep -q 'GitHub Blog' .github/workflows/update-github-info.md
-          grep -q 'GitHub Changelog' .github/workflows/update-github-info.md
+        uses: skills/action-keyphrase-checker@v2
+        with:
+          text-file: .github/workflows/update-github-info.md
+          keyphrase: workflow_dispatch
 
-      - name: Check workflow creates a pull request for Mona
-        id: check-workflow-review
+      - name: Check workflow has a schedule
+        id: check-workflow-schedule
         continue-on-error: true
-        run: |
-          grep -Eiq 'pull request.*Mona|Mona.*pull request|review.*Mona' .github/workflows/update-github-info.md
+        uses: skills/action-keyphrase-checker@v2
+        with:
+          text-file: .github/workflows/update-github-info.md
+          keyphrase: schedule
 
-      - name: Check workflow uses pull request safe output
-        id: check-workflow-safe-output
+      - name: Check README documents the sources
+        id: check-readme-sources
         continue-on-error: true
         run: |
-          grep -q 'safe-outputs' .github/workflows/update-github-info.md
-          grep -q 'create-pull-request' .github/workflows/update-github-info.md
+          grep -q 'GitHub Blog' README.md
+          grep -q 'GitHub Changelog' README.md
 
-      - name: Check workflow declares network access
-        id: check-workflow-network
+      - name: Check README documents Mona review through pull requests
+        id: check-readme-review
         continue-on-error: true
         run: |
-          grep -q 'network' .github/workflows/update-github-info.md
-          grep -q 'github.blog' .github/workflows/update-github-info.md
+          grep -Eiq 'pull request|pull requests' README.md
+          grep -q 'notes/mona-notes.md' README.md
 
       - name: Update comment - step results
         uses: GrantBirki/comment@v2.1.1
@@ -115,28 +104,25 @@ jobs:
           edit-mode: replace
           file: exercise-toolkit/markdown-templates/step-feedback/step-results-table.md
           vars: |
-            step_number: 2
+            step_number: 3
             results_table:
-              - description: "Checked for the website content file"
-                passed: ${{ steps.check-site-file.outcome == 'success' }}
-              - description: "Checked for a Latest GitHub Updates section"
-                passed: ${{ steps.check-site-content.outcome == 'success' }}
               - description: "Checked for .github/workflows/update-github-info.md"
                 passed: ${{ steps.check-workflow-file.outcome == 'success' }}
-              - description: "Checked that the workflow uses Mona's notes, the GitHub Blog, and the GitHub Changelog"
-                passed: ${{ steps.check-workflow-sources.outcome == 'success' }}
-              - description: "Checked that the workflow creates a pull request for Mona"
-                passed: ${{ steps.check-workflow-review.outcome == 'success' }}
-              - description: "Checked that the workflow uses the create-pull-request safe output"
-                passed: ${{ steps.check-workflow-safe-output.outcome == 'success' }}
-              - description: "Checked that the workflow declares network access for GitHub Blog and Changelog sources"
-                passed: ${{ steps.check-workflow-network.outcome == 'success' }}
+              - description: "Checked that the workflow supports workflow_dispatch"
+                passed: ${{ steps.check-workflow-dispatch.outcome == 'success' }}
+              - description: "Checked that the workflow has a schedule"
+                passed: ${{ steps.check-workflow-schedule.outcome == 'success' }}
+              - description: "Checked that README documents the GitHub Blog and GitHub Changelog"
+                passed: ${{ steps.check-readme-sources.outcome == 'success' }}
+              - description: "Checked that README documents Mona's pull request review loop"
+                passed: ${{ steps.check-readme-review.outcome == 'success' }}
 
       - name: Fail job if not all checks passed
         if: contains(steps.*.outcome, 'failure')
         run: exit 1
 
   post_next_step_content:
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     name: Post next step content
     needs: [find_exercise, check_step_work]
     runs-on: ubuntu-latest
@@ -162,14 +148,14 @@ jobs:
           issue-number: ${{ env.ISSUE_NUMBER }}
           file: exercise-toolkit/markdown-templates/step-feedback/step-finished-prepare-next-step.md
           vars: |
-            next_step_number: 3
+            next_step_number: 4
 
       - name: Create comment - add step content
         uses: GrantBirki/comment@v2.1.1
         with:
           repository: ${{ env.ISSUE_REPOSITORY }}
           issue-number: ${{ env.ISSUE_NUMBER }}
-          file: ${{ env.STEP_3_FILE }}
+          file: ${{ env.STEP_4_FILE }}
 
       - name: Create comment - watching for progress
         uses: GrantBirki/comment@v2.1.1
@@ -181,6 +167,7 @@ jobs:
       - name: Disable current workflow and enable next one
         run: |
           gh workflow disable "${{github.workflow}}"
-          gh workflow enable "Step 3"
+          gh workflow enable "Step 4"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/4-last-step.yml
+++ b/.github/workflows/4-last-step.yml
@@ -1,28 +1,26 @@
-name: Step 3 # Last step of the exercise
+name: Step 4 # Last step of the exercise
 
 on:
   workflow_dispatch:
-  pull_request:
-    types: [closed]
-    branches:
-      - main
+  workflow_run:
+    workflows: ["update-github-info"]
+    types: [completed]
 
 permissions:
-  contents: write
+  contents: read
   actions: write
   issues: write
+  pull-requests: read
 
 env:
   REVIEW_FILE: ".github/steps/x-review.md"
 
 jobs:
   find_exercise:
-    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     name: Find Exercise Issue
     uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.9.3
 
   check_step_work:
-    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     name: Check step work
     runs-on: ubuntu-latest
     needs: [find_exercise]
@@ -58,42 +56,52 @@ jobs:
           file: exercise-toolkit/markdown-templates/step-feedback/checking-work.md
           edit-mode: replace
 
-      - name: Check workflow file exists
-        id: check-workflow-file
+      - name: Check Mona notes were updated
+        id: check-notes-request
+        continue-on-error: true
+        uses: skills/action-keyphrase-checker@v2
+        with:
+          text-file: notes/mona-notes.md
+          keyphrase: Mona updater request
+
+      - name: Check compiled workflow exists
+        id: check-lock-file
         continue-on-error: true
         uses: skills/exercise-toolkit/actions/file-exists@v0.9.3
         with:
-          file: .github/workflows/update-github-info.md
+          file: .github/workflows/update-github-info.lock.yml
 
-      - name: Check workflow supports manual runs
-        id: check-workflow-dispatch
+      - name: Check compiled workflow references Copilot secret
+        id: check-copilot-secret
         continue-on-error: true
         uses: skills/action-keyphrase-checker@v2
         with:
-          text-file: .github/workflows/update-github-info.md
-          keyphrase: workflow_dispatch
+          text-file: .github/workflows/update-github-info.lock.yml
+          keyphrase: COPILOT_GITHUB_TOKEN
 
-      - name: Check workflow has a schedule
-        id: check-workflow-schedule
-        continue-on-error: true
-        uses: skills/action-keyphrase-checker@v2
-        with:
-          text-file: .github/workflows/update-github-info.md
-          keyphrase: schedule
-
-      - name: Check README documents the sources
-        id: check-readme-sources
+      - name: Find generated PR that updates website content
+        id: find-generated-pr
         continue-on-error: true
         run: |
-          grep -q 'GitHub Blog' README.md
-          grep -q 'GitHub Changelog' README.md
+          for pr_number in $(gh pr list --state open --limit 20 --json number --jq '.[].number'); do
+            if gh pr diff "$pr_number" --name-only | grep -q '^site/content/github-info.md$'; then
+              echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          echo "No open pull request updates site/content/github-info.md"
+          exit 1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check README documents Mona review through pull requests
-        id: check-readme-review
+      - name: Check generated PR title mentions Mona or GitHub Info
+        id: check-pr-title
         continue-on-error: true
         run: |
-          grep -Eiq 'pull request|pull requests' README.md
-          grep -q 'notes/mona-notes.md' README.md
+          title="$(gh pr view "${{ steps.find-generated-pr.outputs.pr_number }}" --json title --jq .title)"
+          echo "$title" | grep -Eiq 'Mona|GitHub Info|website update'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update comment - step results
         uses: GrantBirki/comment@v2.1.1
@@ -104,25 +112,24 @@ jobs:
           edit-mode: replace
           file: exercise-toolkit/markdown-templates/step-feedback/step-results-table.md
           vars: |
-            step_number: 3
+            step_number: 4
             results_table:
-              - description: "Checked for .github/workflows/update-github-info.md"
-                passed: ${{ steps.check-workflow-file.outcome == 'success' }}
-              - description: "Checked that the workflow supports workflow_dispatch"
-                passed: ${{ steps.check-workflow-dispatch.outcome == 'success' }}
-              - description: "Checked that the workflow has a schedule"
-                passed: ${{ steps.check-workflow-schedule.outcome == 'success' }}
-              - description: "Checked that README documents the GitHub Blog and GitHub Changelog"
-                passed: ${{ steps.check-readme-sources.outcome == 'success' }}
-              - description: "Checked that README documents Mona's pull request review loop"
-                passed: ${{ steps.check-readme-review.outcome == 'success' }}
+              - description: "Checked that Mona's notes include a new updater request"
+                passed: ${{ steps.check-notes-request.outcome == 'success' }}
+              - description: "Checked for .github/workflows/update-github-info.lock.yml"
+                passed: ${{ steps.check-lock-file.outcome == 'success' }}
+              - description: "Checked that the compiled workflow references COPILOT_GITHUB_TOKEN"
+                passed: ${{ steps.check-copilot-secret.outcome == 'success' }}
+              - description: "Checked that an open generated pull request updates site/content/github-info.md"
+                passed: ${{ steps.find-generated-pr.outcome == 'success' }}
+              - description: "Checked that the generated pull request title mentions Mona, GitHub Info, or a website update"
+                passed: ${{ steps.check-pr-title.outcome == 'success' }}
 
       - name: Fail job if not all checks passed
         if: contains(steps.*.outcome, 'failure')
         run: exit 1
 
   post_review_content:
-    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     name: Post review content
     needs: [find_exercise, check_step_work]
     runs-on: ubuntu-latest
@@ -161,7 +168,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   finish_exercise:
-    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     name: Finish Exercise
     needs: [find_exercise, post_review_content]
     uses: skills/exercise-toolkit/.github/workflows/finish-exercise.yml@v0.9.3

--- a/.github/workflows/4-last-step.yml
+++ b/.github/workflows/4-last-step.yml
@@ -3,7 +3,7 @@ name: Step 4 # Last step of the exercise
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: ["update-github-info"]
+    workflows: ["update-github-info", "Update GitHub Info"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/4-last-step.yml
+++ b/.github/workflows/4-last-step.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           repository: ${{ env.ISSUE_REPOSITORY }}
           issue-number: ${{ env.ISSUE_NUMBER }}
+          comment-author: github-actions[bot]
           direction: last
 
       - name: Update comment - checking work

--- a/.github/workflows/4-last-step.yml
+++ b/.github/workflows/4-last-step.yml
@@ -84,7 +84,7 @@ jobs:
         id: find-generated-pr
         continue-on-error: true
         run: |
-          for pr_number in $(gh pr list --state open --limit 20 --json number --jq '.[].number'); do
+          for pr_number in $(gh pr list --state open --limit 100 --json number --jq '.[].number'); do
             if gh pr diff "$pr_number" --name-only | grep -q '^site/content/github-info.md$'; then
               echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
               exit 0

--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ _Learn how to install GitHub Agentic Workflows and create an AI-powered workflow
   - Basic familiarity with GitHub repositories, branches, and pull requests
   - Comfort editing YAML and Markdown files
 
-- **How long**: This exercise takes less than 30 minutes to complete.
+- **How long**: This exercise takes less than 45 minutes to complete.
 
 In this exercise, you will:
 
 1. Install the repository setup for GitHub Agentic Workflows and merge it to `main`.
 1. Create an agentic workflow that drafts website updates in a pull request.
 1. Operationalize the workflow with manual and scheduled runs, and document the human review loop.
+1. Run the workflow and inspect the pull request it creates for Mona.
 
 ### How to start this exercise
 


### PR DESCRIPTION
## Summary
- Add a fourth exercise step where learners configure COPILOT_GITHUB_TOKEN, compile Mona's updater, run it, and inspect the generated PR
- Convert Step 3 from final review into a normal progression step and add a Step 4 workflow_run grader
- Strengthen Step 2 to require safe-outputs/create-pull-request and network configuration
- Add placeholder SVG UI assets for secrets setup, workflow dispatch, generated PR, and PR file review

## Validation
- Parsed all .github/workflows/*.yml with Ruby YAML
- Verified all step image references resolve to files
- Checked new gh-aw/auth/PAT links return HTTP 200
