### PR TITLE
Install CLI tools in Codespaces devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,6 +24,8 @@
         "github.copilot-chat"
       ],
       "settings": {
+        "task.allowAutomaticTasks": "on",
+        "terminal.integrated.defaultLocation": "editor",
         "files.exclude": {
           "**/site/node_modules": true,
           "**/site/.astro": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
   "name": "Mona Astro Website",
   "image": "mcr.microsoft.com/devcontainers/base:jammy",
   "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/node:1": {
       "version": "lts"
     }

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -7,9 +7,6 @@ SITE_DIR="$ROOT_DIR/site"
 echo "[postCreate] Installing GitHub Copilot CLI..."
 npm install -g @github/copilot
 
-echo "[postCreate] Installing GitHub Agentic Workflows CLI extension..."
-curl -sL https://raw.githubusercontent.com/github/gh-aw/main/install-gh-aw.sh | bash
-
 echo "[postCreate] Installing Mona Astro site dependencies..."
 cd "$SITE_DIR"
 npm ci
@@ -17,5 +14,5 @@ npm ci
 echo "[postCreate] Verifying Astro build..."
 npm run build
 
-echo "[postCreate] Done. GitHub CLI, Copilot CLI, and gh-aw are installed."
+echo "[postCreate] Done. GitHub CLI and Copilot CLI are installed."
 echo "[postCreate] Use the 'Mona Astro: Dev Server' launch config or the 'site: dev' task to start the site."

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -4,6 +4,16 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SITE_DIR="$ROOT_DIR/site"
 
+echo "[postCreate] Installing GitHub Copilot CLI..."
+npm install -g @github/copilot
+
+echo "[postCreate] Installing GitHub Agentic Workflows CLI extension..."
+if gh extension list | awk '{print $1}' | grep -qx "gh-aw"; then
+  echo "[postCreate] gh-aw extension already installed."
+else
+  gh extension install github/gh-aw
+fi
+
 echo "[postCreate] Installing Mona Astro site dependencies..."
 cd "$SITE_DIR"
 npm ci
@@ -11,4 +21,5 @@ npm ci
 echo "[postCreate] Verifying Astro build..."
 npm run build
 
-echo "[postCreate] Done. Use the 'Mona Astro: Dev Server' launch config or the 'site: dev' task to start the site."
+echo "[postCreate] Done. GitHub CLI, Copilot CLI, and gh-aw are installed."
+echo "[postCreate] Use the 'Mona Astro: Dev Server' launch config or the 'site: dev' task to start the site."

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -8,11 +8,7 @@ echo "[postCreate] Installing GitHub Copilot CLI..."
 npm install -g @github/copilot
 
 echo "[postCreate] Installing GitHub Agentic Workflows CLI extension..."
-if gh extension list | awk '{print $1}' | grep -qx "gh-aw"; then
-  echo "[postCreate] gh-aw extension already installed."
-else
-  gh extension install github/gh-aw
-fi
+curl -sL https://raw.githubusercontent.com/github/gh-aw/main/install-gh-aw.sh | bash
 
 echo "[postCreate] Installing Mona Astro site dependencies..."
 cd "$SITE_DIR"

--- a/.devcontainer/postStart.sh
+++ b/.devcontainer/postStart.sh
@@ -12,5 +12,6 @@ if [ ! -d node_modules ]; then
 fi
 
 echo "[postStart] Workspace ready."
+echo "[postStart] CLI tools available: gh, copilot, gh aw."
 echo "[postStart] Start the site with the VS Code launch config 'Mona Astro: Dev Server' or the task 'site: dev'."
 echo "[postStart] When running, the site will be available on port 4321."

--- a/.devcontainer/postStart.sh
+++ b/.devcontainer/postStart.sh
@@ -12,6 +12,6 @@ if [ ! -d node_modules ]; then
 fi
 
 echo "[postStart] Workspace ready."
-echo "[postStart] CLI tools available: gh and copilot. You'll install gh-aw in Step 1."
+echo "[postStart] CLI tools available: gh and copilot."
 echo "[postStart] Start the site with the VS Code launch config 'Mona Astro: Dev Server' or the task 'site: dev'."
 echo "[postStart] When running, the site will be available on port 4321."

--- a/.devcontainer/postStart.sh
+++ b/.devcontainer/postStart.sh
@@ -12,6 +12,6 @@ if [ ! -d node_modules ]; then
 fi
 
 echo "[postStart] Workspace ready."
-echo "[postStart] CLI tools available: gh, copilot, gh aw."
+echo "[postStart] CLI tools available: gh and copilot. You'll install gh-aw in Step 1."
 echo "[postStart] Start the site with the VS Code launch config 'Mona Astro: Dev Server' or the task 'site: dev'."
 echo "[postStart] When running, the site will be available on port 4321."

--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -37,7 +37,7 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
 4. In the terminal that opened in the editor, run the official standalone installer to install or update the GitHub Agentic Workflows CLI extension.
 
    ```bash
-   curl -sL https://raw.githubusercontent.com/github/gh-aw/main/install-gh-aw.sh | bash
+   curl -fsSL https://raw.githubusercontent.com/github/gh-aw/main/install-gh-aw.sh | bash
    ```
 
    This standalone installer is the easiest path in Codespaces because it does not depend on interactive `gh extension install` authentication.

--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -44,7 +44,10 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
 
 5. Set up the `COPILOT_GITHUB_TOKEN` repository secret that the Copilot engine will use later in the exercise.
 
-   This exercise is designed for **public** repository copies. If you copied the exercise as a private repository, token setup may require additional account or organization policy configuration.
+   > [!IMPORTANT]
+   > This exercise is designed for **public** repository copies.
+   > If you copied the exercise as a private repository, token setup may
+   > require additional account or organization policy configuration.
 
    1. [Create a fine-grained personal access token](https://github.com/settings/personal-access-tokens/new?name=COPILOT_GITHUB_TOKEN&description=GitHub+Agentic+Workflows+-+Copilot+engine+authentication&user_copilot_requests=read) with **Copilot Requests** set to **Read**.
    2. Copy the token value.

--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -22,7 +22,7 @@ The [`gh aw` CLI](https://github.github.com/gh-aw/setup/cli/) and setup action a
 
 ### :keyboard: Activity: Set up your Codespace and agentic workflow tooling
 
-Let's start in the pre-configured Codespace for this exercise. The dev container installs the website dependencies and enables the GitHub Copilot extensions for VS Code.
+Let's start in the pre-configured Codespace for this exercise. The dev container installs the website dependencies, the GitHub CLI, Copilot CLI, the `gh-aw` extension, and the GitHub Copilot extensions for VS Code.
 
 1. Use the button below to open the **Create Codespace** page in a new tab. Use the default configuration.
 

--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -22,7 +22,7 @@ The [`gh aw` CLI](https://github.github.com/gh-aw/setup/cli/) and setup action a
 
 ### :keyboard: Activity: Set up your Codespace and agentic workflow tooling
 
-Let's start in the pre-configured Codespace for this exercise. The dev container installs the website dependencies, the GitHub CLI, Copilot CLI, the GitHub Copilot extensions for VS Code, and opens a terminal in the editor.
+Let's start in the pre-configured Codespace for this exercise. The dev container installs the website dependencies, the GitHub CLI, Copilot CLI, the GitHub Copilot extensions for VS Code, and opens a terminal in the editor. You'll install the Agentic Workflows CLI yourself in the first activity.
 
 1. Use the button below to open the **Create Codespace** page in a new tab. Use the default configuration.
 

--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -22,7 +22,7 @@ The [`gh aw` CLI](https://github.github.com/gh-aw/setup/cli/) and setup action a
 
 ### :keyboard: Activity: Set up your Codespace and agentic workflow tooling
 
-Let's start in the pre-configured Codespace for this exercise. The dev container installs the website dependencies, the GitHub CLI, Copilot CLI, the `gh-aw` extension, and the GitHub Copilot extensions for VS Code.
+Let's start in the pre-configured Codespace for this exercise. The dev container installs the website dependencies, the GitHub CLI, Copilot CLI, the GitHub Copilot extensions for VS Code, and opens a terminal in the editor.
 
 1. Use the button below to open the **Create Codespace** page in a new tab. Use the default configuration.
 
@@ -34,9 +34,17 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
 
 3. Wait for Visual Studio Code to load in your browser. The `.devcontainer` setup may take a few minutes while it installs dependencies and verifies the Astro site build.
 
-4. Open Copilot Chat and switch to **Agent** mode.
+4. In the terminal that opened in the editor, run the official standalone installer to install or update the GitHub Agentic Workflows CLI extension.
 
-5. Ask Copilot to create the setup workflow for you.
+   ```bash
+   curl -sL https://raw.githubusercontent.com/github/gh-aw/main/install-gh-aw.sh | bash
+   ```
+
+   This standalone installer is the easiest path in Codespaces because it does not depend on interactive `gh extension install` authentication.
+
+5. Open Copilot Chat and switch to **Agent** mode.
+
+6. Ask Copilot to create the setup workflow for you.
 
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
@@ -47,7 +55,7 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
    > Add a job named copilot-setup-steps that runs on ubuntu-latest, checks out the repository, and installs the gh-aw CLI using github/gh-aw/actions/setup-cli@main.
    > ```
 
-6. Review Copilot's suggested changes. The finished file should look similar to this:
+7. Review Copilot's suggested changes. The finished file should look similar to this:
 
    ```yaml
    name: "Copilot Setup Steps"
@@ -70,7 +78,7 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
            uses: github/gh-aw/actions/setup-cli@main
    ```
 
-7. Ask Copilot to commit, push, and open a pull request.
+8. Ask Copilot to commit, push, and open a pull request.
 
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
@@ -79,9 +87,9 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
    > Use the pull request title "Add Copilot setup workflow".
    > ```
 
-8. Merge the pull request into `main`.
+9. Merge the pull request into `main`.
 
-9. Wait about 20 seconds, then refresh the exercise issue for the next step.
+10. Wait about 20 seconds, then refresh the exercise issue for the next step.
 
 <details>
 <summary>Having trouble? 🤷</summary><br/>

--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -42,9 +42,26 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
 
    This standalone installer is the easiest path in Codespaces because it does not depend on interactive `gh extension install` authentication.
 
-5. Open Copilot Chat and switch to **Agent** mode.
+5. Set up the `COPILOT_GITHUB_TOKEN` repository secret that the Copilot engine will use later in the exercise.
 
-6. Ask Copilot to create the setup workflow for you.
+   This exercise is designed for **public** repository copies. If you copied the exercise as a private repository, token setup may require additional account or organization policy configuration.
+
+   1. [Create a fine-grained personal access token](https://github.com/settings/personal-access-tokens/new?name=COPILOT_GITHUB_TOKEN&description=GitHub+Agentic+Workflows+-+Copilot+engine+authentication&user_copilot_requests=read) with **Copilot Requests** set to **Read**.
+   2. Copy the token value.
+   3. In your copied exercise repository, go to **Settings** > **Secrets and variables** > **Actions**.
+   4. Select **New repository secret**.
+   5. Name the secret `COPILOT_GITHUB_TOKEN`, paste the token value, and save it.
+
+   <img width="650" alt="Repository actions secrets settings page" src="../images/actions-secrets-settings.svg" />
+
+   <img width="650" alt="New repository secret form with COPILOT_GITHUB_TOKEN as the secret name" src="../images/add-copilot-github-token-secret.svg" />
+
+   > [!CAUTION]
+   > Never paste a real token into a comment, markdown file, pull request, or Copilot Chat message. Only add it through the repository secrets UI.
+
+6. Open Copilot Chat and switch to **Agent** mode.
+
+7. Ask Copilot to create the setup workflow for you.
 
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
@@ -55,7 +72,7 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
    > Add a job named copilot-setup-steps that runs on ubuntu-latest, checks out the repository, and installs the gh-aw CLI using github/gh-aw/actions/setup-cli@main.
    > ```
 
-7. Review Copilot's suggested changes. The finished file should look similar to this:
+8. Review Copilot's suggested changes. The finished file should look similar to this:
 
    ```yaml
    name: "Copilot Setup Steps"
@@ -78,7 +95,7 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
            uses: github/gh-aw/actions/setup-cli@main
    ```
 
-8. Ask Copilot to commit, push, and open a pull request.
+9. Ask Copilot to commit, push, and open a pull request.
 
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
@@ -87,15 +104,16 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
    > Use the pull request title "Add Copilot setup workflow".
    > ```
 
-9. Merge the pull request into `main`.
+10. Merge the pull request into `main`.
 
-10. Wait about 20 seconds, then refresh the exercise issue for the next step.
+11. Wait about 20 seconds, then refresh the exercise issue for the next step.
 
 <details>
 <summary>Having trouble? 🤷</summary><br/>
 
 - Make sure the file path is exactly `.github/workflows/copilot-setup-steps.yml`.
 - The check looks for the `copilot-setup-steps` job and the `github/gh-aw/actions/setup-cli` action.
+- Make sure `COPILOT_GITHUB_TOKEN` is a repository Actions secret, not a value committed to the repository.
 - Step 1 only completes after your setup pull request is merged into `main`.
 
 </details>

--- a/.github/steps/4-step.md
+++ b/.github/steps/4-step.md
@@ -6,24 +6,15 @@ You now have an agentic workflow definition for Mona's website. In this step, yo
 
 Agentic workflows are authored as markdown files, but GitHub Actions runs compiled `.lock.yml` workflow files. The `gh aw compile` command turns `.github/workflows/update-github-info.md` into `.github/workflows/update-github-info.lock.yml`.
 
-Because this workflow uses the default Copilot engine, the repository needs a `COPILOT_GITHUB_TOKEN` Actions secret before the compiled workflow can run. That secret is a fine-grained personal access token with the **Copilot Requests** account permission.
+Because this workflow uses the default Copilot engine, it needs the `COPILOT_GITHUB_TOKEN` Actions secret you added in Step 1 before the compiled workflow can run.
 
 The workflow uses `safe-outputs: create-pull-request`, so the agent can draft website changes without writing directly to `main`. The agent prepares a patch, and a separate permission-controlled job opens a pull request for Mona to review.
 
 ### :keyboard: Activity: Run the updater and inspect its pull request
 
-1. Confirm the repository has the `COPILOT_GITHUB_TOKEN` secret.
+1. Confirm the repository still has the `COPILOT_GITHUB_TOKEN` Actions secret from Step 1.
 
-   Go to your repository on GitHub, then choose **Settings** > **Secrets and variables** > **Actions**.
-
-   <img width="650" alt="Repository actions secrets settings page" src="../images/actions-secrets-settings.svg" />
-
-   If the secret is missing, [create a fine-grained personal access token](https://github.com/settings/personal-access-tokens/new?name=COPILOT_GITHUB_TOKEN&description=GitHub+Agentic+Workflows+-+Copilot+engine+authentication&user_copilot_requests=read) with **Copilot Requests** set to **Read**, then add it as a repository secret named `COPILOT_GITHUB_TOKEN`.
-
-   <img width="650" alt="New repository secret form with COPILOT_GITHUB_TOKEN as the secret name" src="../images/add-copilot-github-token-secret.svg" />
-
-   > [!CAUTION]
-   > Never paste a real token into a comment, markdown file, pull request, or Copilot Chat message. Only add it through the repository secrets UI.
+   If you need to check, go to **Settings** > **Secrets and variables** > **Actions** in your copied exercise repository. You should see `COPILOT_GITHUB_TOKEN` listed as a repository secret.
 
 2. Ask Copilot to compile and run Mona's updater.
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,7 +15,7 @@
         "background": {
           "activeOnStart": true,
           "beginsPattern": ".",
-          "endsPattern": "^Codespace ready\\. CLI tools available: gh, copilot, and gh aw\\.$"
+          "endsPattern": "^Codespace ready\\. CLI tools available: gh and copilot\\.$"
         }
       },
       "presentation": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,18 @@
       "type": "shell",
       "command": "echo 'Codespace ready. CLI tools available: gh and copilot.' && exec bash -l",
       "isBackground": true,
-      "problemMatcher": [],
+      "problemMatcher": {
+        "owner": "custom",
+        "pattern": {
+          "regexp": "^(.*)$",
+          "message": 1
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".",
+          "endsPattern": "^Codespace ready\\. CLI tools available: gh, copilot, and gh aw\\.$"
+        }
+      },
       "presentation": {
         "reveal": "always",
         "panel": "new",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "workspace: ready terminal",
       "type": "shell",
-      "command": "echo 'Codespace ready. CLI tools available: gh, copilot, and gh aw.' && exec bash -l",
+      "command": "echo 'Codespace ready. CLI tools available: gh and copilot.' && exec bash -l",
       "isBackground": true,
       "problemMatcher": [],
       "presentation": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,22 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "workspace: ready terminal",
+      "type": "shell",
+      "command": "echo 'Codespace ready. CLI tools available: gh, copilot, and gh aw.' && exec bash -l",
+      "isBackground": true,
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "new",
+        "focus": true,
+        "clear": false
+      },
+      "runOptions": {
+        "runOn": "folderOpen"
+      }
+    },
+    {
       "label": "site: install",
       "type": "shell",
       "command": "npm ci",

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ In this exercise, you will:
 
 Simply copy the exercise to your account, then give your favorite Octocat (Mona) **about 20 seconds** to prepare the first lesson, then **refresh the page**.
 
+> [!IMPORTANT]
+> This exercise is designed for **public** repository copies.
+> If you copied the exercise as a private repository, token setup may
+> require additional account or organization policy configuration.
+
 [![](https://img.shields.io/badge/Copy%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/new?template_owner=skills-dev&template_name=getting-started-with-agentic-workflows&owner=%40me&name=skills-getting-started-with-agentic-workflows&description=Exercise:+Getting+Started+with+Agentic+Workflows&visibility=public)
 
 <details>


### PR DESCRIPTION
## Summary
- Add the GitHub CLI devcontainer feature
- Install the standalone Copilot CLI via @github/copilot during post-create
- Install the gh-aw GitHub CLI extension idempotently for local Agentic Workflows commands
- Update Step 1 copy to call out the preinstalled CLI tools

## Validation
- Parsed .devcontainer/devcontainer.json with jq
- Checked postCreate.sh and postStart.sh with bash -n
