### PR TITLE
Simplify Agentic Workflows setup step

### DIFF
--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -1,6 +1,6 @@
-## Step 1: Install agentic workflows and merge the setup
+## Step 1: Initialize agentic workflows and merge the setup
 
-Mona's website needs repository-level setup before an agentic workflow can help. In this step, you'll add the GitHub Agentic Workflows setup workflow and merge it to `main`.
+Mona's website needs repository-level setup before an agentic workflow can help. In this step, you'll initialize GitHub Agentic Workflows setup and merge it to `main`.
 
 ### 📖 Theory: What are Agentic Workflows?
 
@@ -16,9 +16,9 @@ You describe what you want to happen in a markdown file with a YAML frontmatter 
 
 ### 📖 Theory: Setting Up a Repository for Agentic Workflows
 
-GitHub Agentic Workflows use repository files and GitHub Actions to give AI agents a safe, repeatable place to work. A setup workflow can install the `gh aw` tooling for GitHub Actions so future workflows can create or maintain automation in this repository.
+GitHub Agentic Workflows use repository files and GitHub Actions to give AI agents a safe, repeatable place to work. The `gh aw init` command adds the setup files a repository needs for creating, compiling, and running agentic workflows.
 
-The [`gh aw` CLI](https://github.github.com/gh-aw/setup/cli/) and setup action are commonly used to prepare a repository for agentic workflows. In this exercise, you'll add the repository setup as code, review it in a pull request, and then merge it to `main`.
+The [`gh aw` CLI](https://github.github.com/gh-aw/setup/cli/) can prepare the repository, update Codespaces configuration, and open a pull request with the setup changes. In this exercise, you'll review that pull request and merge it to `main`.
 
 ### :keyboard: Activity: Set up your Codespace and agentic workflow tooling
 
@@ -34,7 +34,11 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
 
 3. Wait for Visual Studio Code to load in your browser. The `.devcontainer` setup may take a few minutes while it installs dependencies and verifies the Astro site build.
 
-4. In the terminal that opened in the editor, run the official standalone installer to install or update the GitHub Agentic Workflows CLI extension.
+4. Try Mona's website locally. In the left sidebar, select **Run and Debug**, choose **Mona Astro: Dev Server**, and start the launch configuration.
+
+   When the site starts, open the forwarded port `4321` in your browser and confirm the GitHub Info website loads.
+
+5. In the terminal that opened in the editor, run the official standalone installer to install or update the GitHub Agentic Workflows CLI extension.
 
    ```bash
    curl -fsSL https://raw.githubusercontent.com/github/gh-aw/main/install-gh-aw.sh | bash
@@ -42,7 +46,12 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
 
    This standalone installer is the easiest path in Codespaces because it does not depend on interactive `gh extension install` authentication.
 
-5. Set up the `COPILOT_GITHUB_TOKEN` repository secret that the Copilot engine will use later in the exercise.
+6. Set up the `COPILOT_GITHUB_TOKEN` repository secret that the Copilot engine will use later in the exercise.
+
+   > [!IMPORTANT]
+   > This exercise is designed for **public** repository copies.
+   > If you copied the exercise as a private repository, token setup may
+   > require additional account or organization policy configuration.
 
    1. [Create a fine-grained personal access token](https://github.com/settings/personal-access-tokens/new?name=COPILOT_GITHUB_TOKEN&description=GitHub+Agentic+Workflows+-+Copilot+engine+authentication&user_copilot_requests=read) with **Copilot Requests** set to **Read**.
    2. Copy the token value.
@@ -54,63 +63,38 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
 
    <img width="650" alt="New repository secret form with COPILOT_GITHUB_TOKEN as the secret name" src="../images/add-copilot-github-token-secret.svg" />
 
-> [!CAUTION]
-> Never paste a real token into a comment, markdown file, pull request, or Copilot Chat message. Only add it through the repository secrets UI.
+   > [!CAUTION]
+   > Never paste a real token into a comment, markdown file, pull request, or Copilot Chat message. Only add it through the repository secrets UI.
 
-6. Open Copilot Chat and switch to **Agent** mode.
+7. Open Copilot Chat and switch to **Agent** mode.
 
-7. Ask Copilot to create the setup workflow for you.
-
-   > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
-   >
-   > ```prompt
-   > Create a new branch named install-agentic-workflows.
-   > Add .github/workflows/copilot-setup-steps.yml with a workflow named "Copilot Setup Steps".
-   > The workflow should run on workflow_dispatch and when .github/workflows/copilot-setup-steps.yml changes.
-   > Add a job named copilot-setup-steps that runs on ubuntu-latest, checks out the repository, and installs the gh-aw CLI using github/gh-aw/actions/setup-cli@main.
-   > ```
-
-8. Review Copilot's suggested changes. The finished file should look similar to this:
-
-   ```yaml
-   name: "Copilot Setup Steps"
-
-   on:
-     workflow_dispatch:
-     push:
-       paths:
-         - .github/workflows/copilot-setup-steps.yml
-
-   jobs:
-     copilot-setup-steps:
-       runs-on: ubuntu-latest
-       permissions:
-         contents: read
-       steps:
-         - name: Checkout repository
-           uses: actions/checkout@v6
-         - name: Install gh-aw extension
-           uses: github/gh-aw/actions/setup-cli@main
-   ```
-
-9. Ask Copilot to commit, push, and open a pull request.
+8. Ask Copilot to initialize the repository with `gh aw`.
 
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
    > ```prompt
-   > Commit the setup workflow change, push the install-agentic-workflows branch, and open a pull request into main.
-   > Use the pull request title "Add Copilot setup workflow".
+   > Create a new branch named initialize-agentic-workflows.
+   > Run gh aw init --codespaces --create-pull-request to initialize this repository for GitHub Agentic Workflows.
+   > If the command leaves changes locally instead of opening a pull request, commit the setup changes with the message "Initialize GitHub Agentic Workflows", push the branch, and open a pull request into main.
+   > After the pull request is open, help me review the files that gh aw created.
    > ```
 
-10. Merge the pull request into `main`.
+9. Review the pull request. It should include repository setup files such as:
+
+   - `.github/workflows/copilot-setup-steps.yml`
+   - `.github/agents/agentic-workflows.agent.md`
+   - `.github/mcp.json`
+   - `.gitattributes`
+
+10. Merge the setup pull request into `main`.
 
 11. Wait about 20 seconds, then refresh the exercise issue for the next step.
 
 <details>
 <summary>Having trouble? 🤷</summary><br/>
 
-- Make sure the file path is exactly `.github/workflows/copilot-setup-steps.yml`.
-- The check looks for the `copilot-setup-steps` job and the `github/gh-aw/actions/setup-cli` action.
+- Make sure `gh aw init --codespaces --create-pull-request` ran from your copied exercise repository.
+- The check looks for Agentic Workflows setup files created by `gh aw init`, including `.github/workflows/copilot-setup-steps.yml`, `.github/agents/agentic-workflows.agent.md`, `.github/mcp.json`, and `.gitattributes`.
 - Make sure `COPILOT_GITHUB_TOKEN` is a repository Actions secret, not a value committed to the repository.
 - Step 1 only completes after your setup pull request is merged into `main`.
 

--- a/.github/workflows/1-step.yml
+++ b/.github/workflows/1-step.yml
@@ -71,7 +71,7 @@ jobs:
         uses: skills/action-keyphrase-checker@v2
         with:
           text-file: .github/workflows/copilot-setup-steps.yml
-          keyphrase: github/gh-aw/actions/setup-cli
+          keyphrase: setup-cli
 
       - name: Check workflow has copilot-setup-steps job
         id: check-setup-job
@@ -80,6 +80,28 @@ jobs:
         with:
           text-file: .github/workflows/copilot-setup-steps.yml
           keyphrase: copilot-setup-steps
+
+      - name: Check agentic workflows agent exists
+        id: check-agent-file
+        continue-on-error: true
+        uses: skills/exercise-toolkit/actions/file-exists@v0.9.3
+        with:
+          file: .github/agents/agentic-workflows.agent.md
+
+      - name: Check MCP config exists
+        id: check-mcp-file
+        continue-on-error: true
+        uses: skills/exercise-toolkit/actions/file-exists@v0.9.3
+        with:
+          file: .github/mcp.json
+
+      - name: Check gitattributes tracks lock files
+        id: check-gitattributes
+        continue-on-error: true
+        uses: skills/action-keyphrase-checker@v2
+        with:
+          text-file: .gitattributes
+          keyphrase: .github/workflows/*.lock.yml
 
       - name: Update comment - step results
         uses: GrantBirki/comment@v2.1.1
@@ -98,6 +120,12 @@ jobs:
                 passed: ${{ steps.check-setup-action.outcome == 'success' }}
               - description: "Checked for the copilot-setup-steps job"
                 passed: ${{ steps.check-setup-job.outcome == 'success' }}
+              - description: "Checked for the Agentic Workflows agent file"
+                passed: ${{ steps.check-agent-file.outcome == 'success' }}
+              - description: "Checked for the MCP configuration file"
+                passed: ${{ steps.check-mcp-file.outcome == 'success' }}
+              - description: "Checked that workflow lock files are tracked in .gitattributes"
+                passed: ${{ steps.check-gitattributes.outcome == 'success' }}
 
       - name: Fail job if not all checks passed
         if: contains(steps.*.outcome, 'failure')


### PR DESCRIPTION
## Summary
- update Step 1 to run the Mona site locally before setup
- guide learners to install gh-aw with the standalone installer
- use Copilot Chat to run `gh aw init --codespaces --create-pull-request`
- update the Step 1 grader to check the actual files created by `gh aw init`

## Validation
- Parsed all workflow YAML files
- Validated devcontainer and VS Code JSON
- Checked devcontainer shell scripts with bash -n