### PR TITLE
Update missing instructions and adds a review changes comment 

### DIFF
--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -67,7 +67,8 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
 
    1. In your copied exercise repository, go to **Settings** > **Actions** > **General**.
    2. Under **Workflow permissions**, select **Read and write permissions**.
-   3. Save the changes.
+   3. Check **Allow GitHub Actions to create and approve pull requests**.
+   4. Save the changes.
 
    <details>
      <summary>Actions workflow permissions details</summary><br/>
@@ -90,9 +91,9 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
    - `.github/mcp.json`
    - `.gitattributes`
 
-3.  Merge the setup pull request into `main`.
+10. Merge the setup pull request into `main`.
 
-4.  Wait about 20 seconds, then refresh the exercise issue for the next step.
+11. Wait about 20 seconds, then refresh the exercise issue for the next step.
 
 <details>
 <summary>Having trouble? 🤷</summary><br/>

--- a/.github/steps/2-step.md
+++ b/.github/steps/2-step.md
@@ -29,7 +29,7 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
 
    > 💡 **Tip:** If Copilot doesn't give you quite what you want, you can always continue explaining what you need. Copilot will remember the conversation history for follow-up responses.
 
-3. Now let's use the agentic-workflows agent to create a workflow that opens pull requests with future website updates. Open the **Copilot Chat panel** using `Ctrl + Alt + I` (Windows) or `Cmd + Alt + I` (Mac). Select the **agentic-workflows** agent from the agent selector and give it access to edit files in the repository.
+3. Now let's use the agentic-workflows agent to create a workflow that opens pull requests with future website updates. Open the **Copilot Chat panel** using `Ctrl + Alt + I` (Windows) or `Ctrl + Cmd + I` (Mac). Select the **agentic-workflows** agent from the agent selector and give it access to edit files in the repository.
 
 > [!NOTE]
 > The agentic-workflows agent is a general-purpose agent that can follow instructions in markdown files.

--- a/.github/steps/2-step.md
+++ b/.github/steps/2-step.md
@@ -29,14 +29,21 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
 
    > 💡 **Tip:** If Copilot doesn't give you quite what you want, you can always continue explaining what you need. Copilot will remember the conversation history for follow-up responses.
 
-3. Now let's use the agentic-workflows agent to create a workflow that opens pull requests with future website updates. Ask Copilot to create a new workflow file in `.github/workflows/` and give the agent edit access so it can propose changes to the website content.
+3. Now let's use the agentic-workflows agent to create a workflow that opens pull requests with future website updates. Open the **Copilot Chat panel** using `Ctrl + Alt + I` (Windows) or `Cmd + Alt + I` (Mac). Select the **agentic-workflows** agent from the agent selector and give it access to edit files in the repository.
 
 > [!NOTE]
 > The agentic-workflows agent is a general-purpose agent that can follow instructions in markdown files.
-> Select it from the Copilot Chat agent selector and give it access to edit files in the repository.
 > This will allow the agent to propose changes to the website content and create pull requests for review.
 
    <img width="30%" alt="agentic workflows Agent" src="../images/agentic-workflows-agent.png" />
+
+4. Before prompting the agent, add a rule to `.github/agents/agentic-workflows.agent.md` so the agent knows not to compile workflows on its own. Open the file and add the following line under Important Notes:
+
+   ```markdown
+   When creating or editing agentic workflow files, do not compile them. Only create or update the markdown workflow file.
+   ```
+
+5. Ask the agentic-workflows agent to create the workflow file.
 
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
@@ -53,7 +60,6 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
    >   - web fetch https://github.blog/changelog/
    > - update site/content/github-info.md, and open
    > - a pull request for Mona to review.
-   > Don't compile this workflow yet. Just create the markdown file.
    > ```
 
 ### :keyboard: Activity: Compile the `update-github-info.md` Agentic Workflow

--- a/.github/steps/3-step.md
+++ b/.github/steps/3-step.md
@@ -19,7 +19,7 @@ The workflow uses `safe-outputs: create-pull-request`, so the agent can draft we
 
    If you need to check, go to **Settings** > **Secrets and variables** > **Actions** in your copied exercise repository. You should see `COPILOT_GITHUB_TOKEN` listed as a repository secret.
 
-2. Use **agent-workflows** agent in the Copilot Chat panel to update Mona's updater `.github/workflows/update-github-info.md`.
+2. Open the **Copilot Chat panel** using `Ctrl + Alt + I` (Windows) or `Cmd + Alt + I` (Mac). Select the **agentic-workflows** agent from the Copilot Chat agent selector to update Mona's updater `.github/workflows/update-github-info.md`.
 
    <img width="30%" alt="agentic workflows Agent" src="../images/agentic-workflows-agent.png" />
 
@@ -30,7 +30,6 @@ The workflow uses `safe-outputs: create-pull-request`, so the agent can draft we
    > - Tell agent to:
    >      web fetch https://awesome-copilot.github.com/workflows/
    > - Add to sources awesome-copilot workflows https://awesome-copilot.github.com/workflows/
-   > - Don't compile this workflow yet. Just update the markdown workflow file.
    > ```
 
 3. Compile the agentic workflow file `.github/workflows/update-github-info.md` in the terminal.

--- a/.github/steps/3-step.md
+++ b/.github/steps/3-step.md
@@ -19,7 +19,7 @@ The workflow uses `safe-outputs: create-pull-request`, so the agent can draft we
 
    If you need to check, go to **Settings** > **Secrets and variables** > **Actions** in your copied exercise repository. You should see `COPILOT_GITHUB_TOKEN` listed as a repository secret.
 
-2. Open the **Copilot Chat panel** using `Ctrl + Alt + I` (Windows) or `Cmd + Alt + I` (Mac). Select the **agentic-workflows** agent from the Copilot Chat agent selector to update Mona's updater `.github/workflows/update-github-info.md`.
+2. Open the **Copilot Chat panel** using `Ctrl + Alt + I` (Windows) or `Ctrl + Cmd + I` (Mac). Select the **agentic-workflows** agent from the Copilot Chat agent selector to update Mona's updater `.github/workflows/update-github-info.md`.
 
    <img width="30%" alt="agentic workflows Agent" src="../images/agentic-workflows-agent.png" />
 

--- a/.github/steps/x-review.md
+++ b/.github/steps/x-review.md
@@ -4,6 +4,20 @@ _Congratulations, you've completed **Agentic Workflows That Read the Room** and 
 
 <img src="https://octodex.github.com/images/jetpacktocat.png" alt="celebrate" width=200 align=right>
 
+Pull the latest changes from `main` to get the final updates to the exercise repository, then review your work to see the changes on your website!🎉
+
+<details><summary> Need help to view your changes ? </summary>
+<p>
+
+View Mona's website locally. In the left sidebar(if it's not running yet), select **Run and Debug**, choose **Mona Astro: Dev Server**, and start the launch configuration.
+
+   <img width=30% alt="VS Code Run and Debug" src="../images/mona-astro-site-run-debug.png" />
+
+   When the site starts, open the forwarded port `4321` in your browser and confirm the GitHub Info website loads.
+
+</p>
+</details> 
+
 Here's what you accomplished:
 
 - **Installed agentic workflow setup** — You added the repository workflow that prepares GitHub agentic workflows tooling.


### PR DESCRIPTION
This pull request updates the exercise instructions to clarify the steps for using the agentic-workflows agent, improve workflow permissions guidance, and enhance the review process for learners. The most important changes are grouped below.

**Instruction and workflow clarity:**

* Updated step instructions to explicitly guide users to open the Copilot Chat panel with keyboard shortcuts, select the agentic-workflows agent, and grant it file edit access, ensuring users follow the correct process when creating and updating workflows. (.github/steps/2-step.md [[1]](diffhunk://#diff-6532bc0acf62af4cfba8c15eefabf1f892ab722845ffd0c41aa5f5484ff15aeaL32-R47) .github/steps/3-step.md [[2]](diffhunk://#diff-e8e5fd7d7bc1e2efa65a834c08c24a501bf517d98371f7238cf4526e404c6c86L22-R22)
* Added a new step to instruct users to add a rule to `.github/agents/agentic-workflows.agent.md` that tells the agent not to compile workflows, only to create or update the markdown file. (.github/steps/2-step.md [.github/steps/2-step.mdL32-R47](diffhunk://#diff-6532bc0acf62af4cfba8c15eefabf1f892ab722845ffd0c41aa5f5484ff15aeaL32-R47))
* Removed redundant instructions about not compiling workflows from the user prompt, since this is now handled by the agent rule. (.github/steps/2-step.md [[1]](diffhunk://#diff-6532bc0acf62af4cfba8c15eefabf1f892ab722845ffd0c41aa5f5484ff15aeaL56) .github/steps/3-step.md [[2]](diffhunk://#diff-e8e5fd7d7bc1e2efa65a834c08c24a501bf517d98371f7238cf4526e404c6c86L33)

**Repository settings improvements:**

* Clarified the repository setup instructions by adding a step to check "Allow GitHub Actions to create and approve pull requests" under workflow permissions, and adjusted step numbering for clarity. (.github/steps/1-step.md [[1]](diffhunk://#diff-2c349a17e2176c19559ae7ebf5d27daa4d5fe8d8a2ecbfb695441cfe208a2423L70-R71) [[2]](diffhunk://#diff-2c349a17e2176c19559ae7ebf5d27daa4d5fe8d8a2ecbfb695441cfe208a2423L93-R96)

**End-of-exercise guidance:**

* Added instructions to pull the latest changes from `main` and provided detailed steps (with images) for viewing Mona's website locally using VS Code's Run and Debug feature, helping users review their completed work. (.github/steps/x-review.md [.github/steps/x-review.mdR7-R20](diffhunk://#diff-42f53dcd85649fb11d54c8c516d51edbd0d5ae7f35331fab0aa7f72f90a4b547R7-R20))