### PR TITLE
Improve agentic workflow exercise validation

### DIFF
--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -40,6 +40,12 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
    > curl -fsSL https://raw.githubusercontent.com/github/gh-aw/main/install-gh-aw.sh | bash
    > ```
 
+   Confirm that the extension is available before continuing:
+
+   > ```bash
+   > gh aw version
+   > ```
+
    This standalone installer is the easiest path in Codespaces because it does not depend on interactive `gh extension install` authentication.
 
 6. Set up the `COPILOT_GITHUB_TOKEN` repository secret that the Copilot engine will use later in the exercise.
@@ -80,6 +86,8 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
 
 8. Initialize the repository with `gh aw` in the terminal.
 
+   Run this command from the root of your copied repository. The command opens a setup pull request instead of committing directly to `main`.
+
    > ![Static Badge](https://img.shields.io/badge/Terminal-text?logo=gnometerminal&labelColor=0969da&color=ddf4ff)
    >
    > ```bash
@@ -88,7 +96,7 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
 
 9. Review the pull request that was opened. It should include repository setup files such as:
 
-   - `.github/workflows/copilot-setup-steps.yml`
+   - `.github/skills/agentic-workflows/SKILL.md`
    - `.github/agents/agentic-workflows.md`
    - `.github/mcp.json`
    - `.gitattributes`
@@ -101,7 +109,7 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
 <summary>Having trouble? 🤷</summary><br/>
 
 - Make sure `gh aw init --create-pull-request --completions` ran from your copied exercise repository.
-- The check looks for agentic workflows setup files created by `gh aw init`, including `.github/workflows/copilot-setup-steps.yml`, `.github/agents/agentic-workflows.md`, `.github/mcp.json`, and `.gitattributes`.
+- The check looks for agentic workflows setup files created by `gh aw init`, including `.github/skills/agentic-workflows/SKILL.md`, `.github/agents/agentic-workflows.md`, `.github/mcp.json`, and `.gitattributes`.
 - Make sure `COPILOT_GITHUB_TOKEN` is a repository Actions secret, not a value committed to the repository.
 - Step 1 only completes after your setup pull request is merged into `main`.
 

--- a/.github/steps/x-review.md
+++ b/.github/steps/x-review.md
@@ -20,7 +20,7 @@ View Mona's website locally. In the left sidebar(if it's not running yet), selec
 
 Here's what you accomplished:
 
-- **Installed agentic workflow setup** — You added the repository workflow that prepares GitHub agentic workflows tooling.
+- **Installed agentic workflow setup** — You added the dispatcher skill, custom agent, MCP configuration, and Git attributes that prepare the repository for GitHub agentic workflows.
 - **Created a website updater** — You drafted a workflow for Mona's GitHub Info website that uses repository notes plus the GitHub Blog and GitHub Changelog, and compiles it to a `.lock.yml` workflow file.
 - **Added a new source site to the workflow** — You updated the workflow to include the [awesome-copilot workflows](https://awesome-copilot.github.com/workflows/) site as a source for `.github/workflows/update-github-info.md` and recompiled it.
 - **Ran the agentic workflow** — You compiled Mona's updater, ran it, and inspected the pull request it generated.

--- a/.github/workflows/1-step.yml
+++ b/.github/workflows/1-step.yml
@@ -58,28 +58,12 @@ jobs:
           file: exercise-toolkit/markdown-templates/step-feedback/checking-work.md
           edit-mode: replace
 
-      - name: Check setup workflow exists
-        id: check-setup-file
+      - name: Check dispatcher skill exists
+        id: check-skill-file
         continue-on-error: true
         uses: skills/exercise-toolkit/actions/file-exists@v0.9.3
         with:
-          file: .github/workflows/copilot-setup-steps.yml
-
-      - name: Check workflow installs gh-aw
-        id: check-setup-action
-        continue-on-error: true
-        uses: skills/action-keyphrase-checker@v2
-        with:
-          text-file: .github/workflows/copilot-setup-steps.yml
-          keyphrase: setup-cli
-
-      - name: Check workflow has copilot-setup-steps job
-        id: check-setup-job
-        continue-on-error: true
-        uses: skills/action-keyphrase-checker@v2
-        with:
-          text-file: .github/workflows/copilot-setup-steps.yml
-          keyphrase: copilot-setup-steps
+          file: .github/skills/agentic-workflows/SKILL.md
 
       - name: Check agentic workflows agent exists
         id: check-agent-file
@@ -98,9 +82,10 @@ jobs:
       - name: Check gitattributes tracks lock files
         id: check-gitattributes
         continue-on-error: true
-        uses: skills/exercise-toolkit/actions/file-exists@v0.9.3
+        uses: skills/action-keyphrase-checker@v2
         with:
-          file: .gitattributes
+          text-file: .gitattributes
+          keyphrase: .github/workflows/*.lock.yml
 
       - name: Update comment - step results
         uses: GrantBirki/comment@v2.1.1
@@ -113,17 +98,13 @@ jobs:
           vars: |
             step_number: 1
             results_table:
-              - description: "Checked for .github/workflows/copilot-setup-steps.yml"
-                passed: ${{ steps.check-setup-file.outcome == 'success' }}
-              - description: "Checked that the setup workflow installs gh-aw"
-                passed: ${{ steps.check-setup-action.outcome == 'success' }}
-              - description: "Checked for the copilot-setup-steps job"
-                passed: ${{ steps.check-setup-job.outcome == 'success' }}
+              - description: "Checked for the agentic workflows dispatcher skill"
+                passed: ${{ steps.check-skill-file.outcome == 'success' }}
               - description: "Checked for the Agentic Workflows agent file"
                 passed: ${{ steps.check-agent-file.outcome == 'success' }}
               - description: "Checked for the MCP configuration file"
                 passed: ${{ steps.check-mcp-file.outcome == 'success' }}
-              - description: "Checked that workflow lock files are tracked in .gitattributes"
+              - description: "Checked that .gitattributes tracks workflow lock files"
                 passed: ${{ steps.check-gitattributes.outcome == 'success' }}
 
       - name: Fail job if not all checks passed

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -91,8 +91,16 @@ jobs:
         continue-on-error: true
         run: |
           grep -q 'notes/mona-notes.md' .github/workflows/update-github-info.md
-          grep -q 'GitHub Blog' .github/workflows/update-github-info.md
-          grep -q 'GitHub Changelog' .github/workflows/update-github-info.md
+          grep -q 'https://github.blog/latest/' .github/workflows/update-github-info.md
+          grep -q 'https://github.blog/changelog/' .github/workflows/update-github-info.md
+
+      - name: Check workflow has the expected name
+        id: check-workflow-name
+        continue-on-error: true
+        uses: skills/action-keyphrase-checker@v2
+        with:
+          text-file: .github/workflows/update-github-info.md
+          keyphrase: "name: update-github-info"
 
       - name: Check workflow creates a pull request for Mona
         id: check-workflow-review
@@ -106,6 +114,21 @@ jobs:
         run: |
           grep -q 'safe-outputs' .github/workflows/update-github-info.md
           grep -q 'create-pull-request' .github/workflows/update-github-info.md
+
+      - name: Check workflow enables edit and web fetch tools
+        id: check-workflow-tools
+        continue-on-error: true
+        run: |
+          grep -q "edit:" .github/workflows/update-github-info.md
+          grep -q "web-fetch:" .github/workflows/update-github-info.md
+
+      - name: Check workflow supports manual runs
+        id: check-workflow-dispatch
+        continue-on-error: true
+        uses: skills/action-keyphrase-checker@v2
+        with:
+          text-file: .github/workflows/update-github-info.md
+          keyphrase: workflow_dispatch
 
       - name: Check workflow declares network access
         id: check-workflow-network
@@ -136,10 +159,16 @@ jobs:
                 passed: ${{ steps.check-agent-no-compile.outcome == 'success' }}
               - description: "Checked that the workflow uses Mona's notes, the GitHub Blog, and the GitHub Changelog"
                 passed: ${{ steps.check-workflow-sources.outcome == 'success' }}
+              - description: "Checked that the workflow has the expected name"
+                passed: ${{ steps.check-workflow-name.outcome == 'success' }}
               - description: "Checked that the workflow creates a pull request for Mona"
                 passed: ${{ steps.check-workflow-review.outcome == 'success' }}
               - description: "Checked that the workflow uses the create-pull-request safe output"
                 passed: ${{ steps.check-workflow-safe-output.outcome == 'success' }}
+              - description: "Checked that the workflow enables edit and web fetch tools"
+                passed: ${{ steps.check-workflow-tools.outcome == 'success' }}
+              - description: "Checked that the workflow supports manual runs"
+                passed: ${{ steps.check-workflow-dispatch.outcome == 'success' }}
               - description: "Checked that the workflow declares network access for GitHub Blog and Changelog sources"
                 passed: ${{ steps.check-workflow-network.outcome == 'success' }}
 

--- a/.github/workflows/3-step.yml
+++ b/.github/workflows/3-step.yml
@@ -105,6 +105,7 @@ jobs:
 
       - name: Check generated PR title mentions Mona or GitHub Info
         id: check-pr-title
+        if: steps.find-generated-pr.outcome == 'success'
         continue-on-error: true
         run: |
           title="$(gh pr view "${{ steps.find-generated-pr.outputs.pr_number }}" --json title --jq .title)"
@@ -112,6 +113,7 @@ jobs:
 
       - name: Check generated PR includes source context
         id: check-pr-sources
+        if: steps.find-generated-pr.outcome == 'success'
         continue-on-error: true
         run: |
           gh pr diff "${{ steps.find-generated-pr.outputs.pr_number }}" | grep -Eiq 'GitHub Blog|GitHub Changelog|github.blog|github.com'

--- a/.github/workflows/3-step.yml
+++ b/.github/workflows/3-step.yml
@@ -21,6 +21,7 @@ jobs:
     uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.9.3
 
   check_step_work:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     name: Check step work
     runs-on: ubuntu-latest
     needs: [find_exercise]
@@ -63,7 +64,7 @@ jobs:
         uses: skills/action-keyphrase-checker@v2
         with:
           text-file: .github/workflows/update-github-info.md
-          keyphrase: "awesome-copilot.github.com"
+          keyphrase: "https://awesome-copilot.github.com/workflows/"
           case-sensitive: false
 
       - name: Check compiled workflow exists
@@ -85,12 +86,16 @@ jobs:
         id: find-generated-pr
         continue-on-error: true
         run: |
-          for pr_number in $(gh pr list --state open --limit 100 --json number --jq '.[].number'); do
+          run_created_at="${{ github.event.workflow_run.created_at }}"
+          while IFS=$'	' read -r pr_number created_at; do
+            if [ -n "$run_created_at" ] && [[ "$created_at" < "$run_created_at" ]]; then
+              continue
+            fi
             if gh pr diff "$pr_number" --name-only | grep -q '^site/content/github-info.md$'; then
               echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-          done
+          done < <(gh pr list --state open --base main --limit 100 --json number,createdAt --jq '.[] | [.number, .createdAt] | @tsv')
           echo "No open pull request updates site/content/github-info.md"
           exit 1
         env:
@@ -102,6 +107,12 @@ jobs:
         run: |
           title="$(gh pr view "${{ steps.find-generated-pr.outputs.pr_number }}" --json title --jq .title)"
           echo "$title" | grep -Eiq 'Mona|GitHub Info|website update'
+
+      - name: Check generated PR includes source context
+        id: check-pr-sources
+        continue-on-error: true
+        run: |
+          gh pr diff "${{ steps.find-generated-pr.outputs.pr_number }}" | grep -Eiq 'GitHub Blog|GitHub Changelog|github.blog|github.com'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -126,6 +137,8 @@ jobs:
                 passed: ${{ steps.find-generated-pr.outcome == 'success' }}
               - description: "Checked that the generated pull request title mentions Mona, GitHub Info, or a website update"
                 passed: ${{ steps.check-pr-title.outcome == 'success' }}
+              - description: "Checked that the generated pull request includes source context"
+                passed: ${{ steps.check-pr-sources.outcome == 'success' }}
 
       - name: Fail job if not all checks passed
         if: contains(steps.*.outcome, 'failure')

--- a/.github/workflows/3-step.yml
+++ b/.github/workflows/3-step.yml
@@ -86,9 +86,11 @@ jobs:
         id: find-generated-pr
         continue-on-error: true
         run: |
-          run_created_at="${{ github.event.workflow_run.created_at }}"
-          while IFS=$'	' read -r pr_number created_at; do
-            if [ -n "$run_created_at" ] && [[ "$created_at" < "$run_created_at" ]]; then
+          run_created_at="${{ github.event.workflow_run.run_started_at || github.run_started_at }}"
+          run_created_epoch="$(date -u -d "$run_created_at" +%s 2>/dev/null || echo 0)"
+          while IFS=$'\t' read -r pr_number created_at; do
+            created_epoch="$(date -u -d "$created_at" +%s 2>/dev/null || echo 0)"
+            if [ "$run_created_epoch" -ne 0 ] && [ "$created_epoch" -lt "$run_created_epoch" ]; then
               continue
             fi
             if gh pr diff "$pr_number" --name-only | grep -q '^site/content/github-info.md$'; then

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ _Learn how to install GitHub Agentic Workflows and create an AI-powered workflow
 
 - **Who is this for**: Developers, DevOps engineers, and anyone curious about AI-powered automation in GitHub repositories.
 - **What you'll learn**: How to install the `gh aw` extension, author an agentic workflow in markdown, and run it so proposed changes flow through pull requests.
-- **What you'll build**: A repository setup workflow plus an agentic workflow that drafts updates to Mona's GitHub Info website using her notes, the GitHub Blog, and the GitHub Changelog—then opens a pull request for review.
+- **What you'll build**: Repository-level agentic workflow setup plus an agentic workflow that drafts updates to Mona's GitHub Info website using her notes, the GitHub Blog, and the GitHub Changelog—then opens a pull request for review.
 - **Prerequisites**:
   - A GitHub account with access to GitHub Copilot
   - Basic familiarity with GitHub repositories, branches, and pull requests


### PR DESCRIPTION
## Why

The exercise checks and guidance had drifted from the current `gh aw init` output and could accept stale or incomplete learner results.

## What changed

- Update Step 1 for the dispatcher skill, current setup artifacts, and `gh aw version` confirmation.
- Validate the `.gitattributes` lock-file rule rather than only checking file existence.
- Strengthen Step 2 checks for exact source URLs, workflow metadata, required tools, and manual dispatch.
- Prevent Step 3 from advancing after failed updater runs or matching stale PRs, and verify generated source context.
- Refresh README and completion wording to describe the current setup.

## Validation

- Parsed all exercise workflow YAML files.
- Ran `git diff --check`.

## Source issue

N/A