### PR TITLE
Use Copilot engine in Step 1 gh aw init and validate its output

### DIFF
--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -91,7 +91,7 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
    > ![Static Badge](https://img.shields.io/badge/Terminal-text?logo=gnometerminal&labelColor=0969da&color=ddf4ff)
    >
    > ```bash
-   > gh aw init --create-pull-request --completions
+   > gh aw init --create-pull-request --engine copilot --completions
    > ```
 
 9. Review the pull request that was opened. It should include repository setup files such as:
@@ -99,6 +99,7 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
    - `.github/skills/agentic-workflows/SKILL.md`
    - `.github/agents/agentic-workflows.md`
    - `.github/mcp.json`
+   - `.github/workflows/copilot-setup-steps.yml`
    - `.gitattributes`
 
 10. Merge the setup pull request into `main`.
@@ -108,8 +109,8 @@ Let's start in the pre-configured Codespace for this exercise. The dev container
 <details>
 <summary>Having trouble? 🤷</summary><br/>
 
-- Make sure `gh aw init --create-pull-request --completions` ran from your copied exercise repository.
-- The check looks for agentic workflows setup files created by `gh aw init`, including `.github/skills/agentic-workflows/SKILL.md`, `.github/agents/agentic-workflows.md`, `.github/mcp.json`, and `.gitattributes`.
+- Make sure `gh aw init --create-pull-request --engine copilot --completions` ran from your copied exercise repository.
+- The check looks for agentic workflows setup files created by `gh aw init`, including `.github/skills/agentic-workflows/SKILL.md`, `.github/agents/agentic-workflows.md`, `.github/mcp.json`, `.github/workflows/copilot-setup-steps.yml`, and `.gitattributes`.
 - Make sure `COPILOT_GITHUB_TOKEN` is a repository Actions secret, not a value committed to the repository.
 - Step 1 only completes after your setup pull request is merged into `main`.
 

--- a/.github/workflows/1-step.yml
+++ b/.github/workflows/1-step.yml
@@ -79,6 +79,13 @@ jobs:
         with:
           file: .github/mcp.json
 
+      - name: Check Copilot setup steps workflow exists
+        id: check-copilot-setup-steps
+        continue-on-error: true
+        uses: skills/exercise-toolkit/actions/file-exists@v0.9.3
+        with:
+          file: .github/workflows/copilot-setup-steps.yml
+
       - name: Check gitattributes tracks lock files
         id: check-gitattributes
         continue-on-error: true
@@ -104,6 +111,8 @@ jobs:
                 passed: ${{ steps.check-agent-file.outcome == 'success' }}
               - description: "Checked for the MCP configuration file"
                 passed: ${{ steps.check-mcp-file.outcome == 'success' }}
+              - description: "Checked for the Copilot setup steps workflow"
+                passed: ${{ steps.check-copilot-setup-steps.outcome == 'success' }}
               - description: "Checked that .gitattributes tracks workflow lock files"
                 passed: ${{ steps.check-gitattributes.outcome == 'success' }}
 


### PR DESCRIPTION
## Why

The Step 1 `gh aw init` command did not specify an engine, so it generated a different set of setup files than the exercise documented and validated. Learners running the copilot-based flow saw an extra `.github/workflows/copilot-setup-steps.yml` file that the step never mentioned and the validation workflow never checked, creating a mismatch between the instructions and reality.

## What changed

- **Step command** (`.github/steps/1-step.md`): now runs `gh aw init --create-pull-request --engine copilot --completions`, matching the Copilot engine used throughout the exercise.
- **Expected file list + troubleshooting**: added `.github/workflows/copilot-setup-steps.yml` so the documented setup files match what `--engine copilot` actually generates.
- **Validation** (`.github/workflows/1-step.yml`): added a `file-exists` check and results-table row for `.github/workflows/copilot-setup-steps.yml`, so completion now confirms the learner used the Copilot engine.

## Notes

Verified against the reference PR output: `--engine copilot` produces `.gitattributes`, `.github/agents/agentic-workflows.md`, `.github/mcp.json`, `.github/skills/agentic-workflows/SKILL.md`, and `.github/workflows/copilot-setup-steps.yml`. The generated `.gitattributes` still contains `.github/workflows/*.lock.yml`, so the existing keyphrase check is unaffected. Workflow YAML was validated.