### PR TITLE
Fix .gitattributes lock-file check keyphrase escaping in Step 1

### DIFF
--- a/.github/workflows/1-step.yml
+++ b/.github/workflows/1-step.yml
@@ -92,7 +92,7 @@ jobs:
         uses: skills/action-keyphrase-checker@v2
         with:
           text-file: .gitattributes
-          keyphrase: .github/workflows/*.lock.yml
+          keyphrase: '\.github/workflows/\*\.lock\.yml'
 
       - name: Update comment - step results
         uses: GrantBirki/comment@v2.1.1


### PR DESCRIPTION
## Why

The Step 1 check **"Checked that .gitattributes tracks workflow lock files"** failed even when a learner's `.gitattributes` correctly contained the `.github/workflows/*.lock.yml` line generated by `gh aw init`. This blocks learners on the very first step through no fault of their own.

## Root cause

`skills/action-keyphrase-checker` compiles the `keyphrase` input directly into a regex via `new RegExp(keyphrase)`. The keyphrase `.github/workflows/*.lock.yml` was therefore interpreted as a regular expression, where:

- `*` is a quantifier applied to the preceding `/` (zero-or-more slashes)
- each `.` matches any character

That combination cannot match its own literal source text, so the checker reported 0 occurrences and the step failed.

## Fix

Escape the regex metacharacters so the keyphrase matches the literal path:

```yaml
keyphrase: '\.github/workflows/\*\.lock\.yml'
```

Verified that the original keyphrase matches 0 times against the generated `.gitattributes` content while the escaped version matches once. This is the only keyphrase across the exercise workflows that contains a `*`, so no other checks are affected.