### PR TITLE
Make Step 2 grading deterministic and agent-consistent

### DIFF
--- a/.github/steps/2-step.md
+++ b/.github/steps/2-step.md
@@ -6,7 +6,10 @@ Nice work getting the repository ready. Now it's time to build the first agentic
 
 An agentic workflow can read repository context, compare sources, draft changes, and open a pull request for human review. That makes it a great fit for Mona's website, where updates should be prepared automatically but still reviewed before they are published.
 
-In this step, you'll create a workflow definition in `.github/workflows/` and pair it with a real content update in the website source. Your workflow should tell the agent to read Mona's notes, check the GitHub Blog and the GitHub Changelog, and then prepare a pull request for Mona to review.
+In this step, you'll create an agentic workflow definition in `.github/workflows/` and compile it into a hardened workflow. Your workflow should tell the agent to read Mona's notes, check the GitHub Blog and the GitHub Changelog, and then prepare a pull request for Mona to review.
+
+> [!NOTE]
+> This step uses two surfaces: the **Copilot Chat** agentic-workflows agent authors and edits the workflow markdown, and the **terminal** runs `gh aw compile` and Git. Author in Chat, compile and commit in the terminal.
 
 ### :keyboard: Activity: Create Mona's updater workflow
 
@@ -14,7 +17,7 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
 
 1. In the new ![Static Badge](https://img.shields.io/badge/Terminal-text?logo=gnometerminal&labelColor=0969da&color=ddf4ff) **terminal window**, use the keyboard shortcut `Ctrl + I` (Windows) or `Cmd + I` (Mac) to bring up **Copilot's Terminal Inline Chat**.
 
-2. Ask Copilot to help create a branch, update a file, and publish the work.
+2. Ask Copilot to start you on the latest `main` and create a working branch.
 
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
@@ -22,9 +25,6 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
    > Hey copilot, 
    > - Make sure I am on the latest main branch
    > - Create a new branch named create-mona-updater
-   > - Update site/content/github-info.md with a new section
-   >   named "Latest GitHub Updates" and include at least
-   >   one concise update for readers.
    > ```
 
    > 💡 **Tip:** If Copilot doesn't give you quite what you want, you can always continue explaining what you need. Copilot will remember the conversation history for follow-up responses.
@@ -74,7 +74,7 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
    > gh aw compile .github/workflows/update-github-info.md
    > ```
 
-2. Review Copilot's suggested changes. Make sure `site/content/github-info.md` includes `## Latest GitHub Updates`.
+2. Confirm the compile succeeded and generated the hardened `.github/workflows/update-github-info.lock.yml` next to your markdown workflow.
 
 3. In `.github/workflows/update-github-info.md`, make sure Copilot clearly instructed the agent to:
 
@@ -91,21 +91,21 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
    name: update-github-info
    description: Draft website updates for Mona's GitHub Info site from official GitHub sources.
    on:
-   workflow_dispatch:
-   schedule:
-      - cron: '17 9 * * *'
+     workflow_dispatch:
+     schedule:
+       - cron: '17 9 * * *'
    safe-outputs:
-   create-pull-request:
-      title-prefix: "[mona] "
-      draft: true
-      fallback-as-issue: false
+     create-pull-request:
+       title-prefix: "[mona] "
+       draft: true
+       fallback-as-issue: false
    tools:
-   edit:
-   web-fetch:
+     edit:
+     web-fetch:
    network:
-   allowed:
-      - github.com
-      - github.blog
+     allowed:
+       - github.com
+       - github.blog
    ---
 
    # Update Mona's GitHub Info website
@@ -134,7 +134,7 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
    > ```prompt
-   > - Commit the website content and Agentic Workflow changes.
+   > - Commit the agentic workflow markdown and the compiled .lock.yml file.
    > - Push the create-mona-updater branch.
    > - Open a pull request into main.
    > - Use the pull request title "Create Mona website updater workflow".
@@ -145,7 +145,7 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
 <details>
 <summary>Having trouble? 🤷</summary><br/>
 
-- The grading check looks for both a website content update and a new workflow file.
+- The grading check looks for the agentic workflow markdown and its compiled `.github/workflows/update-github-info.lock.yml`, so make sure you ran `gh aw compile` and committed both files.
 - Include the phrases `GitHub Blog`, `GitHub Changelog`, `safe-outputs`, `create-pull-request`, and `pull request` in `.github/workflows/update-github-info.md`.
 - Keep your workflow in markdown (`.md`) so the exercise focuses on the agent instructions.
 

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           text-file: .github/agents/agentic-workflows.md
           keyphrase: do not compile
+          case-sensitive: false
 
       - name: Check workflow uses all three sources
         id: check-workflow-sources
@@ -124,9 +125,8 @@ jobs:
         id: check-workflow-network
         continue-on-error: true
         run: |
-          grep -qi 'ALLOWED_DOMAINS' .github/workflows/update-github-info.lock.yml
-          grep -q 'github.blog' .github/workflows/update-github-info.lock.yml
-          grep -q 'github.com' .github/workflows/update-github-info.lock.yml
+          grep -qi 'github.blog' .github/workflows/update-github-info.lock.yml
+          grep -qi 'github.com' .github/workflows/update-github-info.lock.yml
 
       - name: Update comment - step results
         uses: GrantBirki/comment@v2.1.1

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -56,21 +56,6 @@ jobs:
           file: exercise-toolkit/markdown-templates/step-feedback/checking-work.md
           edit-mode: replace
 
-      - name: Check website content file exists
-        id: check-site-file
-        continue-on-error: true
-        uses: skills/exercise-toolkit/actions/file-exists@v0.9.3
-        with:
-          file: site/content/github-info.md
-
-      - name: Check website includes latest updates section
-        id: check-site-content
-        continue-on-error: true
-        uses: skills/action-keyphrase-checker@v2
-        with:
-          text-file: site/content/github-info.md
-          keyphrase: Latest GitHub Updates
-
       - name: Check workflow file exists
         id: check-workflow-file
         continue-on-error: true
@@ -78,29 +63,34 @@ jobs:
         with:
           file: .github/workflows/update-github-info.md
 
+      - name: Check compiled workflow exists
+        id: check-lock-file
+        continue-on-error: true
+        uses: skills/exercise-toolkit/actions/file-exists@v0.9.3
+        with:
+          file: .github/workflows/update-github-info.lock.yml
+
       - name: Check agent instructions include no auto-compile rule
         id: check-agent-no-compile
         continue-on-error: true
         uses: skills/action-keyphrase-checker@v2
         with:
           text-file: .github/agents/agentic-workflows.md
-          keyphrase: Only create or update the markdown workflow file.
+          keyphrase: do not compile
 
       - name: Check workflow uses all three sources
         id: check-workflow-sources
         continue-on-error: true
         run: |
           grep -q 'notes/mona-notes.md' .github/workflows/update-github-info.md
-          grep -q 'https://github.blog/latest/' .github/workflows/update-github-info.md
-          grep -q 'https://github.blog/changelog/' .github/workflows/update-github-info.md
+          grep -qi 'github.blog/latest' .github/workflows/update-github-info.md
+          grep -qi 'github.blog/changelog' .github/workflows/update-github-info.md
 
-      - name: Check workflow has the expected name
+      - name: Check compiled workflow has the expected name
         id: check-workflow-name
         continue-on-error: true
-        uses: skills/action-keyphrase-checker@v2
-        with:
-          text-file: .github/workflows/update-github-info.md
-          keyphrase: "name: update-github-info"
+        run: |
+          grep -Eiq 'name:[[:space:]]*"?update-github-info"?' .github/workflows/update-github-info.lock.yml
 
       - name: Check workflow creates a pull request for Mona
         id: check-workflow-review
@@ -119,8 +109,8 @@ jobs:
         id: check-workflow-tools
         continue-on-error: true
         run: |
-          grep -q "edit:" .github/workflows/update-github-info.md
-          grep -q "web-fetch:" .github/workflows/update-github-info.md
+          grep -qi "edit:" .github/workflows/update-github-info.md
+          grep -qi "web-fetch:" .github/workflows/update-github-info.md
 
       - name: Check workflow supports manual runs
         id: check-workflow-dispatch
@@ -130,13 +120,13 @@ jobs:
           text-file: .github/workflows/update-github-info.md
           keyphrase: workflow_dispatch
 
-      - name: Check workflow declares network access
+      - name: Check compiled workflow declares network access
         id: check-workflow-network
         continue-on-error: true
         run: |
-          grep -q 'network' .github/workflows/update-github-info.md
-          grep -q 'github.blog' .github/workflows/update-github-info.md
-          grep -q 'github.com' .github/workflows/update-github-info.md
+          grep -qi 'ALLOWED_DOMAINS' .github/workflows/update-github-info.lock.yml
+          grep -q 'github.blog' .github/workflows/update-github-info.lock.yml
+          grep -q 'github.com' .github/workflows/update-github-info.lock.yml
 
       - name: Update comment - step results
         uses: GrantBirki/comment@v2.1.1
@@ -149,17 +139,15 @@ jobs:
           vars: |
             step_number: 2
             results_table:
-              - description: "Checked for the website content file"
-                passed: ${{ steps.check-site-file.outcome == 'success' }}
-              - description: "Checked for a Latest GitHub Updates section"
-                passed: ${{ steps.check-site-content.outcome == 'success' }}
               - description: "Checked for .github/workflows/update-github-info.md"
                 passed: ${{ steps.check-workflow-file.outcome == 'success' }}
+              - description: "Checked for the compiled .github/workflows/update-github-info.lock.yml"
+                passed: ${{ steps.check-lock-file.outcome == 'success' }}
               - description: "Checked that the agent instructions include the no auto-compile rule"
                 passed: ${{ steps.check-agent-no-compile.outcome == 'success' }}
               - description: "Checked that the workflow uses Mona's notes, the GitHub Blog, and the GitHub Changelog"
                 passed: ${{ steps.check-workflow-sources.outcome == 'success' }}
-              - description: "Checked that the workflow has the expected name"
+              - description: "Checked that the compiled workflow has the expected name"
                 passed: ${{ steps.check-workflow-name.outcome == 'success' }}
               - description: "Checked that the workflow creates a pull request for Mona"
                 passed: ${{ steps.check-workflow-review.outcome == 'success' }}
@@ -169,7 +157,7 @@ jobs:
                 passed: ${{ steps.check-workflow-tools.outcome == 'success' }}
               - description: "Checked that the workflow supports manual runs"
                 passed: ${{ steps.check-workflow-dispatch.outcome == 'success' }}
-              - description: "Checked that the workflow declares network access for GitHub Blog and Changelog sources"
+              - description: "Checked that the compiled workflow declares network access for GitHub Blog and Changelog sources"
                 passed: ${{ steps.check-workflow-network.outcome == 'success' }}
 
       - name: Fail job if not all checks passed

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -91,7 +91,7 @@ jobs:
         id: check-workflow-name
         continue-on-error: true
         run: |
-          grep -Eiq 'name:[[:space:]]*"?update-github-info"?' .github/workflows/update-github-info.lock.yml
+          grep -Eiq '^name:[[:space:]]*"?update-github-info"?' .github/workflows/update-github-info.lock.yml
 
       - name: Check workflow creates a pull request for Mona
         id: check-workflow-review
@@ -125,8 +125,8 @@ jobs:
         id: check-workflow-network
         continue-on-error: true
         run: |
-          grep -qi 'github.blog' .github/workflows/update-github-info.lock.yml
-          grep -qi 'github.com' .github/workflows/update-github-info.lock.yml
+          grep -qi '"github.blog"' .github/workflows/update-github-info.lock.yml
+          grep -qi '"github.com"' .github/workflows/update-github-info.lock.yml
 
       - name: Update comment - step results
         uses: GrantBirki/comment@v2.1.1


### PR DESCRIPTION
## Why

Step 2 was failing intermittently (see run 31136854173) on three checks: the "Latest GitHub Updates" section, the workflow name, and network access. The root cause was that grading exact-matched strings inside a workflow file authored non-deterministically by the agentic-workflows agent, and it coupled a manual website edit into a step whose real job is authoring the workflow. On top of that, the reference YAML learners were told to copy had flattened indentation, so `gh aw compile` was not reproducible.

## Approach

Grade the deterministic compiled artifact instead of the agent's free-form markdown, and move the runtime website outcome to where it actually happens (Step 3).

- **Fix the malformed sample workflow YAML** in `2-step.md` so `on:`, `safe-outputs:`, `tools:`, and `network:` nest correctly. Verified the fixed sample compiles cleanly with `gh aw compile`.
- **Remove the manual "Latest GitHub Updates" site edit** from Step 2. That section is produced by running the workflow in Step 3, which already grades the generated pull request touching `site/content/github-info.md`.
- **Grade name and network access from `update-github-info.lock.yml`** (the deterministic compile output). Added a compiled-lock existence check and made committing the `.lock.yml` explicit so the artifact reaches `main`.
- **Relax the remaining `.md` checks** (tools, sources, no-compile rule) so normal agent phrasing variance passes.
- **Document the hybrid flow**: author in Copilot Chat with the agentic-workflows agent, then compile and commit in the terminal.

## Validation

Compiled the corrected reference workflow with `gh aw` and ran the exact new grep patterns from `2-step.yml` against the produced artifacts. All nine checks pass (name, network, sources, PR-for-Mona, safe-output, tools, dispatch, and both file-existence checks). The updated `2-step.yml` also lints as valid YAML.

## Notes for reviewers

Grading now depends on the committed `.lock.yml` landing on `main`, which the updated Step 2 commit prompt makes explicit. The network check intentionally requires `github.blog` in the compiled allowlist so web-fetch to the Blog and Changelog stays meaningful; if a learner substitutes the `github` ecosystem identifier for the domains, that is by design flagged.
