### PR TITLE
Make Step 2 agent prompts and grading reliable

### DIFF
--- a/.github/steps/2-step.md
+++ b/.github/steps/2-step.md
@@ -61,6 +61,8 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
    > - update site/content/github-info.md, and open
    > - a pull request for Mona to review.
    > - Check the syntax of the configuration for the agentic workflow is valid
+   > - If you need public guidance or reference files, read them with
+   >   GitHub repository API tools instead of terminal, CLI, or sandboxed commands
    > - Don't compile the workflow
    > ```
 

--- a/.github/steps/2-step.md
+++ b/.github/steps/2-step.md
@@ -50,8 +50,10 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
    > ```prompt
    > - Create .github/workflows/update-github-info.md
    >   as an agentic workflow markdown file.
+   > - Set the frontmatter name to exactly update-github-info.
    > - Run the workflow on daily or on demand with workflow_dispatch.
    > - Give the workflow edit access through the tools configuration.
+   > - Set network.allowed to include github.blog and github.com.
    > - Use safe-outputs with create-pull-request so the agent can
    >   propose changes without writing directly to main.
    > - Tell the agent to:
@@ -137,9 +139,10 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
    > ```prompt
-   > - Commit the agentic workflow markdown and the compiled .lock.yml file.
-   > - Push the create-mona-updater branch.
-   > - Open a pull request into main.
+   > - Commit all changed files, including the agentic workflow markdown
+   >   and the compiled .lock.yml file.
+   > - Push the latest commits to the existing create-mona-updater branch.
+   > - Open a pull request into main if one does not already exist.
    > - Use the pull request title "Create Mona website updater workflow".
    > ```
 
@@ -148,7 +151,7 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
 <details>
 <summary>Having trouble? 🤷</summary><br/>
 
-- The grading check looks for the agentic workflow markdown and its compiled `.github/workflows/update-github-info.lock.yml`, so make sure you ran `gh aw compile` and committed both files.
+- The grading check looks for the agentic workflow markdown and its compiled `.github/workflows/update-github-info.lock.yml`, so make sure you ran `gh aw compile` and committed all changed files.
 - Include the phrases `GitHub Blog`, `GitHub Changelog`, `safe-outputs`, `create-pull-request`, and `pull request` in `.github/workflows/update-github-info.md`.
 - Keep your workflow in markdown (`.md`) so the exercise focuses on the agent instructions.
 

--- a/.github/steps/2-step.md
+++ b/.github/steps/2-step.md
@@ -61,8 +61,9 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
    > - update site/content/github-info.md, and open
    > - a pull request for Mona to review.
    > - Check the syntax of the configuration for the agentic workflow is valid
-   > - If you need public guidance or reference files, read them with
-   >   GitHub repository API tools instead of terminal, CLI, or sandboxed commands
+   > - Read external public guidance with web-fetch
+   > - Read repository guidance or reference files with GitHub repository API tools
+   >   instead of terminal, CLI, or sandboxed commands
    > - Don't compile the workflow
    > ```
 

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -91,7 +91,13 @@ jobs:
         id: check-workflow-name
         continue-on-error: true
         run: |
-          grep -Eiq '^name:[[:space:]]*"?update-github-info"?' .github/workflows/update-github-info.lock.yml
+          workflow_name="$(
+            sed -n 's/^name:[[:space:]]*//p' .github/workflows/update-github-info.lock.yml |
+              head -n 1 |
+              tr '[:upper:]' '[:lower:]' |
+              tr -cd '[:alnum:]'
+          )"
+          test "$workflow_name" = "updategithubinfo"
 
       - name: Check workflow creates a pull request for Mona
         id: check-workflow-review
@@ -121,12 +127,22 @@ jobs:
           text-file: .github/workflows/update-github-info.md
           keyphrase: workflow_dispatch
 
-      - name: Check compiled workflow declares network access
+      - name: Check workflow allows access to GitHub Blog
         id: check-workflow-network
         continue-on-error: true
         run: |
-          grep -qi '"github.blog"' .github/workflows/update-github-info.lock.yml
-          grep -qi '"github.com"' .github/workflows/update-github-info.lock.yml
+          awk '
+            /^network:[[:space:]]*/ {
+              network = 1
+              print
+              next
+            }
+            network && /^[^[:space:]-][^:]*:/ {
+              exit
+            }
+            network
+          ' .github/workflows/update-github-info.md |
+            grep -qi 'github\.blog'
 
       - name: Update comment - step results
         uses: GrantBirki/comment@v2.1.1
@@ -157,7 +173,7 @@ jobs:
                 passed: ${{ steps.check-workflow-tools.outcome == 'success' }}
               - description: "Checked that the workflow supports manual runs"
                 passed: ${{ steps.check-workflow-dispatch.outcome == 'success' }}
-              - description: "Checked that the compiled workflow declares network access for GitHub Blog and Changelog sources"
+              - description: "Checked that the workflow allows network access to the GitHub Blog and Changelog source"
                 passed: ${{ steps.check-workflow-network.outcome == 'success' }}
 
       - name: Fail job if not all checks passed


### PR DESCRIPTION
Step 2 could send learners through unnecessary sandbox approvals and then fail grading for valid agent-authored variations. The final publishing prompt also assumed only two files changed and treated the learner branch as newly pushed.

This update tightens the workflow-authoring prompt around the required name and network domains, directs reference reads through the appropriate non-CLI tools, and tells Copilot to commit every changed file and push the latest commits to the existing branch. Grading now normalizes harmless workflow-name formatting while verifying `github.blog` specifically inside the source workflow's `network` block, avoiding compiler-layout brittleness and false positives from source URLs elsewhere in the file.