### PR TITLE
Make Step 2 and Step 3 grading deterministic

### DIFF
--- a/.github/steps/2-step.md
+++ b/.github/steps/2-step.md
@@ -61,6 +61,8 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
    > - update site/content/github-info.md, and open
    > - a pull request for Mona to review.
    > - Check the syntax of the configuration for the agentic workflow is valid
+   > - If you need public guidance or reference files, read them with
+   >   GitHub repository API tools instead of terminal, CLI, or sandboxed commands
    > - Don't compile the workflow
    > ```
 

--- a/.github/steps/2-step.md
+++ b/.github/steps/2-step.md
@@ -50,8 +50,10 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
    > ```prompt
    > - Create .github/workflows/update-github-info.md
    >   as an agentic workflow markdown file.
+   > - Set the frontmatter name to exactly update-github-info.
    > - Run the workflow on daily or on demand with workflow_dispatch.
    > - Give the workflow edit access through the tools configuration.
+   > - Set network.allowed to include github.blog and github.com.
    > - Use safe-outputs with create-pull-request so the agent can
    >   propose changes without writing directly to main.
    > - Tell the agent to:
@@ -137,9 +139,10 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
    > ```prompt
-   > - Commit the agentic workflow markdown and the compiled .lock.yml file.
-   > - Push the create-mona-updater branch.
-   > - Open a pull request into main.
+   > - Commit all changed files, including the agentic workflow markdown
+   >   and the compiled .lock.yml file.
+   > - Push the latest commits to the existing create-mona-updater branch.
+   > - Open a pull request into main if one does not already exist.
    > - Use the pull request title "Create Mona website updater workflow".
    > ```
 
@@ -148,7 +151,7 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
 <details>
 <summary>Having trouble? 🤷</summary><br/>
 
-- The grading check looks for the agentic workflow markdown and its compiled `.github/workflows/update-github-info.lock.yml`, so make sure you ran `gh aw compile` and committed both files.
+- The grading check looks for the agentic workflow markdown and its compiled `.github/workflows/update-github-info.lock.yml`, so make sure you ran `gh aw compile` and committed all changed files.
 - Include the phrases `GitHub Blog`, `GitHub Changelog`, `safe-outputs`, `create-pull-request`, and `pull request` in `.github/workflows/update-github-info.md`.
 - Keep your workflow in markdown (`.md`) so the exercise focuses on the agent instructions.
 

--- a/.github/steps/2-step.md
+++ b/.github/steps/2-step.md
@@ -61,8 +61,9 @@ Continue working in VS Code. If you closed your browser editor, reopen your deve
    > - update site/content/github-info.md, and open
    > - a pull request for Mona to review.
    > - Check the syntax of the configuration for the agentic workflow is valid
-   > - If you need public guidance or reference files, read them with
-   >   GitHub repository API tools instead of terminal, CLI, or sandboxed commands
+   > - Read external public guidance with web-fetch
+   > - Read repository guidance or reference files with GitHub repository API tools
+   >   instead of terminal, CLI, or sandboxed commands
    > - Don't compile the workflow
    > ```
 

--- a/.github/steps/3-step.md
+++ b/.github/steps/3-step.md
@@ -26,10 +26,15 @@ The workflow uses `safe-outputs: create-pull-request`, so the agent can draft we
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
    > ```prompt
-   > - Update .github/workflows/update-github-info.md workflow
+   > - Update the .github/workflows/update-github-info.md workflow.
+   > - Keep its existing sources and network access.
    > - Tell agent to:
-   >      web fetch https://awesome-copilot.github.com/workflows/
-   > - Add to sources awesome-copilot workflows https://awesome-copilot.github.com/workflows/
+   >   - web fetch https://awesome-copilot.github.com/workflows/
+   > - Add Awesome Copilot workflows to the sources:
+   >   https://awesome-copilot.github.com/workflows/
+   > - Add awesome-copilot.github.com to network.allowed without removing
+   >   the existing GitHub Blog network access.
+   > - Don't compile the workflow.
    > ```
 
 3. Compile the agentic workflow file `.github/workflows/update-github-info.md` in the ![Static Badge](https://img.shields.io/badge/Terminal-text?logo=gnometerminal&labelColor=0969da&color=ddf4ff) **terminal window**.
@@ -40,20 +45,23 @@ The workflow uses `safe-outputs: create-pull-request`, so the agent can draft we
    > gh aw compile .github/workflows/update-github-info.md
    > ```
 
-4. In the new ![Static Badge](https://img.shields.io/badge/Terminal-text?logo=gnometerminal&labelColor=0969da&color=ddf4ff) **terminal window**, use the keyboard shortcut Ctrl + I (Windows) or Cmd + I (Mac) to bring up Copilot's Terminal Inline Chat.
+4. Confirm the compile succeeded and updated `.github/workflows/update-github-info.lock.yml`.
+
+5. In the new ![Static Badge](https://img.shields.io/badge/Terminal-text?logo=gnometerminal&labelColor=0969da&color=ddf4ff) **terminal window**, use the keyboard shortcut Ctrl + I (Windows) or Cmd + I (Mac) to bring up Copilot's Terminal Inline Chat.
 
    Ask Copilot to commit, push, and open a pull request.
 
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
    > ```prompt
-   > - Commit the website content and Agentic Workflow changes.
-   > - Push to the `create-mona-updater` branch
-   > - Open a pull request into main.
+   > - Commit all changed files, including the agentic workflow markdown
+   >   and the updated compiled .lock.yml file.
+   > - Push the latest commits to the existing `create-mona-updater` branch.
+   > - Open a pull request into main if one does not already exist.
    > - Use the pull request title "Update Mona website updater workflow".
    > ```
 
-5. In the GitHub UI merge the pull request, then open the **Actions** tab, select the `update-github-info` workflow, and choose **Run workflow**.
+6. In the GitHub UI merge the pull request, then open the **Actions** tab, select the `update-github-info` workflow, and choose **Run workflow**.
 
    <img width="30%" alt="Run the update-github-info workflow" src="../images/run-update-github-info-1.png" />
 
@@ -61,21 +69,21 @@ The workflow uses `safe-outputs: create-pull-request`, so the agent can draft we
 
    <img width="50%" height="50%" alt="Run the update-github-info workflow" src="../images/run-update-github-info-3.png" />
 
-6. Wait for the workflow to create a pull request for Mona's website update.
+7. Wait for the workflow to create a pull request for Mona's website update.
 
    <img width="50%" alt="Pull request list showing a generated Mona website update pull request" src="../images/generated-update-pr.svg" />
 
-7. Open the generated pull request and review the **Files changed** tab. Confirm it updates `site/content/github-info.md` and mentions the source of the update.
+8. Open the generated pull request and review the **Files changed** tab. Confirm it updates `site/content/github-info.md` and mentions the source of the update.
 
    <img width="50%" alt="Pull request files changed tab showing site/content/github-info.md" src="../images/pr-files-changed-github-info.svg" />
 
-8. Leave the generated pull request open. When the updater workflow finishes, Mona will look for an open pull request that updates `site/content/github-info.md`. Wait about 20 seconds, then refresh the exercise issue for the final review.
+9. Leave the generated pull request open. When the updater workflow finishes, Mona will look for an open pull request that updates `site/content/github-info.md`. Wait about 20 seconds, then refresh the exercise issue for the final review.
 
 <details>
 <summary>Having trouble? 🤷</summary><br/>
 
 - If the workflow fails before the agent starts, confirm `COPILOT_GITHUB_TOKEN` is configured as an Actions secret.
-- If compilation fails, make sure `.github/workflows/update-github-info.md` includes `safe-outputs`, `create-pull-request`, `workflow_dispatch`, and a `network` allowlist.
+- If compilation fails, make sure `.github/workflows/update-github-info.md` includes `safe-outputs`, `create-pull-request`, `workflow_dispatch`, and a `network` allowlist for the GitHub Blog and Awesome Copilot sources.
 - If no pull request appears, open the failed workflow run from the **Actions** tab and review the logs.
 - If the pull request opens as a draft, that is expected. Mona should review generated website changes before they merge.
 

--- a/.github/steps/3-step.md
+++ b/.github/steps/3-step.md
@@ -47,7 +47,7 @@ The workflow uses `safe-outputs: create-pull-request`, so the agent can draft we
 
 4. Confirm the compile succeeded and updated `.github/workflows/update-github-info.lock.yml`.
 
-5. In the new ![Static Badge](https://img.shields.io/badge/Terminal-text?logo=gnometerminal&labelColor=0969da&color=ddf4ff) **terminal window**, use the keyboard shortcut Ctrl + I (Windows) or Cmd + I (Mac) to bring up Copilot's Terminal Inline Chat.
+5. In the terminal window, use the keyboard shortcut Ctrl + I (Windows) or Cmd + I (Mac) to bring up Copilot's Terminal Inline Chat.
 
    Ask Copilot to commit, push, and open a pull request.
 

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -131,18 +131,22 @@ jobs:
         id: check-workflow-network
         continue-on-error: true
         run: |
-          awk '
-            /^network:[[:space:]]*/ {
-              network = 1
-              print
-              next
-            }
-            network && /^[^[:space:]-][^:]*:/ {
-              exit
-            }
-            network
-          ' .github/workflows/update-github-info.md |
-            grep -qi 'github\.blog'
+          network_config="$(
+            awk '
+              /^network:[[:space:]]*/ {
+                network = 1
+                print
+                next
+              }
+              network && /^[^[:space:]-][^:]*:/ {
+                exit
+              }
+              network
+            ' .github/workflows/update-github-info.md |
+              tr -d "\"'"
+          )"
+          printf '%s\n' "$network_config" |
+            grep -Eqi '(^|[][[:space:],-])github(\.blog)?([][[:space:],]|$)'
 
       - name: Update comment - step results
         uses: GrantBirki/comment@v2.1.1

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -91,7 +91,13 @@ jobs:
         id: check-workflow-name
         continue-on-error: true
         run: |
-          grep -Eiq '^name:[[:space:]]*"?update-github-info"?' .github/workflows/update-github-info.lock.yml
+          workflow_name="$(
+            sed -n 's/^name:[[:space:]]*//p' .github/workflows/update-github-info.lock.yml |
+              head -n 1 |
+              tr '[:upper:]' '[:lower:]' |
+              tr -cd '[:alnum:]'
+          )"
+          test "$workflow_name" = "updategithubinfo"
 
       - name: Check workflow creates a pull request for Mona
         id: check-workflow-review
@@ -121,12 +127,22 @@ jobs:
           text-file: .github/workflows/update-github-info.md
           keyphrase: workflow_dispatch
 
-      - name: Check compiled workflow declares network access
+      - name: Check workflow allows access to GitHub Blog
         id: check-workflow-network
         continue-on-error: true
         run: |
-          grep -qi '"github.blog"' .github/workflows/update-github-info.lock.yml
-          grep -qi '"github.com"' .github/workflows/update-github-info.lock.yml
+          awk '
+            /^network:[[:space:]]*/ {
+              network = 1
+              print
+              next
+            }
+            network && /^[^[:space:]-][^:]*:/ {
+              exit
+            }
+            network
+          ' .github/workflows/update-github-info.md |
+            grep -qi 'github\.blog'
 
       - name: Update comment - step results
         uses: GrantBirki/comment@v2.1.1
@@ -157,7 +173,7 @@ jobs:
                 passed: ${{ steps.check-workflow-tools.outcome == 'success' }}
               - description: "Checked that the workflow supports manual runs"
                 passed: ${{ steps.check-workflow-dispatch.outcome == 'success' }}
-              - description: "Checked that the compiled workflow declares network access for GitHub Blog and Changelog sources"
+              - description: "Checked that the workflow allows network access to the GitHub Blog and Changelog source"
                 passed: ${{ steps.check-workflow-network.outcome == 'success' }}
 
       - name: Fail job if not all checks passed

--- a/.github/workflows/3-step.yml
+++ b/.github/workflows/3-step.yml
@@ -82,12 +82,37 @@ jobs:
           text-file: .github/workflows/update-github-info.lock.yml
           keyphrase: COPILOT_GITHUB_TOKEN
 
+      - name: Check workflow allows access to Awesome Copilot
+        id: check-awesome-copilot-network
+        continue-on-error: true
+        run: |
+          network_config="$(
+            awk '
+              /^network:[[:space:]]*/ {
+                network = 1
+                print
+                next
+              }
+              network && /^[^[:space:]-][^:]*:/ {
+                exit
+              }
+              network
+            ' .github/workflows/update-github-info.md |
+              tr -d "\"'"
+          )"
+          printf '%s\n' "$network_config" |
+            grep -Eqi '(^|[][[:space:],-])(awesome-copilot\.)?github\.com([][[:space:],]|$)|(^|[][[:space:],-])github([][[:space:],]|$)'
+
       - name: Find generated PR that updates website content
         id: find-generated-pr
         continue-on-error: true
         run: |
-          run_created_at="${{ github.event.workflow_run.run_started_at || github.run_started_at }}"
-          run_created_epoch="$(date -u -d "$run_created_at" +%s 2>/dev/null || echo 0)"
+          run_created_at="${{ github.event.workflow_run.run_started_at || '' }}"
+          if [ -n "$run_created_at" ]; then
+            run_created_epoch="$(date -u -d "$run_created_at" +%s 2>/dev/null || echo 0)"
+          else
+            run_created_epoch=0
+          fi
           while IFS=$'\t' read -r pr_number created_at; do
             created_epoch="$(date -u -d "$created_at" +%s 2>/dev/null || echo 0)"
             if [ "$run_created_epoch" -ne 0 ] && [ "$created_epoch" -lt "$run_created_epoch" ]; then
@@ -116,7 +141,10 @@ jobs:
         if: steps.find-generated-pr.outcome == 'success'
         continue-on-error: true
         run: |
-          gh pr diff "${{ steps.find-generated-pr.outputs.pr_number }}" | grep -Eiq 'GitHub Blog|GitHub Changelog|github.blog|github.com'
+          {
+            gh pr view "${{ steps.find-generated-pr.outputs.pr_number }}" --json body --jq .body
+            gh pr diff "${{ steps.find-generated-pr.outputs.pr_number }}"
+          } | grep -Eiq 'GitHub Blog|GitHub Changelog|github\.blog|awesome-copilot\.github\.com'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -137,6 +165,8 @@ jobs:
                 passed: ${{ steps.check-lock-file.outcome == 'success' }}
               - description: "Checked that the compiled workflow references COPILOT_GITHUB_TOKEN"
                 passed: ${{ steps.check-copilot-secret.outcome == 'success' }}
+              - description: "Checked that the workflow allows network access to the Awesome Copilot source"
+                passed: ${{ steps.check-awesome-copilot-network.outcome == 'success' }}
               - description: "Checked that an open generated pull request updates site/content/github-info.md"
                 passed: ${{ steps.find-generated-pr.outcome == 'success' }}
               - description: "Checked that the generated pull request title mentions Mona, GitHub Info, or a website update"


### PR DESCRIPTION
The exercise still rejected an in-progress learner whose valid workflow used the documented `github` network preset, and Step 3 had similar prompt-to-grader gaps that could produce inconsistent outcomes or make manual reruns miss an existing generated pull request.

This follow-up:
- accepts either the `github` preset or explicit `github.blog` access in Step 2 while limiting the match to the `network` block;
- makes Step 3 preserve existing sources, add Awesome Copilot network access, compile, and commit all changed files;
- validates Step 3 network access using equivalent GitHub configurations;
- lets manually rerun Step 3 grading discover an existing open generated pull request; and
- accepts source context in either the generated pull request body or its content diff.

The updated Step 2 check was exercised directly against the reported copied-repository workflow.